### PR TITLE
Fix default exports

### DIFF
--- a/@types/ol-ext/control/Bar.d.ts
+++ b/@types/ol-ext/control/Bar.d.ts
@@ -23,7 +23,7 @@ export interface Options {
  *	@param {bool} options.autoDeactivate used with subbar to deactivate all control when top level control deactivate, default false
  *	@param {Array<_ol_control_>} options.controls a list of control to add to the bar
  */
-export class Bar extends ol_control_Control {
+export default class Bar extends ol_control_Control {
     constructor(options?: Options);
     /** Set the control visibility
     * @param {boolean} b

--- a/@types/ol-ext/control/Button.d.ts
+++ b/@types/ol-ext/control/Button.d.ts
@@ -18,7 +18,7 @@ export interface Options {
 *	@param {String} options.html html to insert in the control
 *	@param {function} options.handleClick callback when control is clicked (or use change:active event)
  */
-export class Button extends ol_control_Control {
+export default class Button extends ol_control_Control {
     constructor(options?: Options);
     /** Set the control visibility
     * @param {boolean} b

--- a/@types/ol-ext/control/CanvasAttribution.d.ts
+++ b/@types/ol-ext/control/CanvasAttribution.d.ts
@@ -1,5 +1,5 @@
 import { Map as _ol_Map_ } from 'ol';
-import { default as ol_control_Attribution } from 'ol/control/Attribution';
+import Attribution from 'ol/control/Attribution';
 import { Style } from 'ol/style';
 
 export interface Options {
@@ -15,7 +15,7 @@ export interface Options {
  * @param {Object=} options extend the contrAttribution options.
  * 	@param {Style} options.style  option is usesd to draw the text.
  */
-export class CanvasAttribution extends ol_control_Attribution {
+export default class CanvasAttribution extends Attribution {
     constructor(options?: Options);
     /**
      * Draw attribution on canvas

--- a/@types/ol-ext/control/CanvasBase.d.ts
+++ b/@types/ol-ext/control/CanvasBase.d.ts
@@ -29,7 +29,7 @@ export interface Options {
  * @param {Object=} options extend the control options.
  *  @param {Style} options.style style used to draw the title.
  */
-export class CanvasBase extends ol_control_Control {
+export default class CanvasBase extends ol_control_Control {
     constructor(options?: Options);
     /**
      * Remove the control from its current map and attach it to the new map.

--- a/@types/ol-ext/control/CanvasScaleLine.d.ts
+++ b/@types/ol-ext/control/CanvasScaleLine.d.ts
@@ -15,7 +15,7 @@ export interface Options {
  * @param {Object=} options extend the contrScaleLine options.
  * 	@param {Style} options.style used to draw the scale line (default is black/white, 10px Arial).
  */
-export class CanvasScaleLine extends ol_control_ScaleLine {
+export default class CanvasScaleLine extends ol_control_ScaleLine {
     constructor(options?: Options);
     /**
      * Remove the control from its current map and attach it to the new map.

--- a/@types/ol-ext/control/CanvasTitle.d.ts
+++ b/@types/ol-ext/control/CanvasTitle.d.ts
@@ -1,6 +1,6 @@
 import { Map as _ol_Map_ } from 'ol';
 import { Style } from 'ol/style';
-import { CanvasBase } from './CanvasBase';
+import CanvasBase from './CanvasBase';
 
 export interface Options {
     title: string;
@@ -15,7 +15,7 @@ export interface Options {
  *  @param {string} options.title the title, default 'Title'
  *  @param {Style} options.style style used to draw the title.
  */
-export class CanvasTitle extends CanvasBase {
+export default class CanvasTitle extends CanvasBase {
     constructor(options?: Options);
     /**
      * Change the control style

--- a/@types/ol-ext/control/CenterPosition.d.ts
+++ b/@types/ol-ext/control/CenterPosition.d.ts
@@ -2,7 +2,7 @@ import { Map as _ol_Map_ } from 'ol';
 import { CoordinateFormat } from 'ol/coordinate';
 import { ProjectionLike } from 'ol/proj';
 import { Style } from 'ol/style';
-import { CanvasBase } from './CanvasBase';
+import CanvasBase from './CanvasBase';
 
 export interface Options {
     className: string;
@@ -23,7 +23,7 @@ export interface Options {
  *  @param {Coordinate.CoordinateFormat} options.coordinateFormat A function that takes a Coordinate and transforms it into a string.
  *  @param {boolean} options.canvas true to draw in the canvas
  */
-export class CenterPosition extends CanvasBase {
+export default class CenterPosition extends CanvasBase {
     constructor(options?: Options);
     /**
      * Change the control style

--- a/@types/ol-ext/control/Compass.d.ts
+++ b/@types/ol-ext/control/Compass.d.ts
@@ -1,6 +1,6 @@
 import { Map as _ol_Map_ } from 'ol';
 import { Stroke, Image } from 'ol/style';
-import { CanvasBase } from './CanvasBase';
+import CanvasBase from './CanvasBase';
 
 export interface Options {
     className: string;
@@ -21,7 +21,7 @@ export interface Options {
  *  @param {boolean} options.rotateVithView rotate vith view (false to show watermark), default true
  *  @param {style.Stroke} options.style style to draw the lines, default draw no lines
  */
-export class Compass extends CanvasBase {
+export default class Compass extends CanvasBase {
     constructor(options?: Options);
     /**
      * Remove the control from its current map and attach it to the new map.

--- a/@types/ol-ext/control/Disable.d.ts
+++ b/@types/ol-ext/control/Disable.d.ts
@@ -16,7 +16,7 @@ export interface Options {
  *		@param {bool} options.on the control is on
  *		@param {function} options.toggleFn callback when control is clicked
  */
-export class Disable extends ol_control_Control {
+export default class Disable extends ol_control_Control {
     constructor(options?: Options);
     /** Test if the control is on
      * @return {bool}

--- a/@types/ol-ext/control/EditBar.d.ts
+++ b/@types/ol-ext/control/EditBar.d.ts
@@ -2,7 +2,7 @@ import { Map as _ol_Map_ } from 'ol';
 import ol_control_Control from 'ol/control/Control';
 import { Vector as VectorSource } from 'ol/source';
 import Event from 'ol/events/Event';
-import { Bar } from './Bar';
+import Bar from './Bar';
 import { position } from './control';
 
 export interface Options {
@@ -25,7 +25,7 @@ export interface Options {
  *    Each interaction can be an interaction or true (to get the default one) or false to remove it from bar
  *	@param {VectorSource} options.source Source for the drawn features.
  */
-export class EditBar extends Bar {
+export default class EditBar extends Bar {
     constructor(options?: Options);
     /**
      * Set the map instance the control is associated with

--- a/@types/ol-ext/control/Gauge.d.ts
+++ b/@types/ol-ext/control/Gauge.d.ts
@@ -16,7 +16,7 @@ export interface Options {
  *		@param {number} options.max maximum value, default 100;
  *		@param {number} options.val the value, default 0
  */
-export class Gauge extends ol_control_Control {
+export default class Gauge extends ol_control_Control {
     constructor(options?: Options);
     /** Set the control title
     * @param {string} title

--- a/@types/ol-ext/control/GeoBookmark.d.ts
+++ b/@types/ol-ext/control/GeoBookmark.d.ts
@@ -29,7 +29,7 @@ var bm = new GeoBookmark ({
   }
 });
  */
-export class GeoBookmark extends ol_control_Control {
+export default class GeoBookmark extends ol_control_Control {
     constructor(options: Options);
     /** Set bookmarks
     * @param {} bmark a list of bookmarks, default retreave in the localstorage

--- a/@types/ol-ext/control/GeolocationBar.d.ts
+++ b/@types/ol-ext/control/GeolocationBar.d.ts
@@ -1,7 +1,7 @@
 import { Map as _ol_Map_ } from 'ol';
 import ol_control_Control from 'ol/control/Control';
 import Event from 'ol/events/Event';
-import { Bar } from './Bar';
+import Bar from './Bar';
 import { position } from './control';
 
 export interface Options {
@@ -18,7 +18,7 @@ export interface Options {
  *	@param {String} options.className class of the control
  *	@param {String} options.centerLabel label for center button, default center
  */
-export class GeolocationBar extends Bar {
+export default class GeolocationBar extends Bar {
     constructor(options?: Options);
     /** Get the interaction.GeolocationDraw associatedwith the bar
      *

--- a/@types/ol-ext/control/Globe.d.ts
+++ b/@types/ol-ext/control/Globe.d.ts
@@ -14,7 +14,7 @@ import { options } from './control';
  * 	@param {Array<layer>} layers list of layers to display on the globe
  * 	@param {Style | Array.<Style> | undefined} style style to draw the position on the map , default a marker
  */
-export class Globe extends ol_control_Control {
+export default class Globe extends ol_control_Control {
     constructor(options?: options);
     /**
      * Set the map instance the control associated with.

--- a/@types/ol-ext/control/Graticule.d.ts
+++ b/@types/ol-ext/control/Graticule.d.ts
@@ -1,5 +1,5 @@
-import { Map as _ol_Map_ } from 'ol';
-import { CanvasBase } from './CanvasBase';
+import { Map } from 'ol';
+import CanvasBase from './CanvasBase';
 /**
  * Draw a graticule on the map.
  *
@@ -15,7 +15,7 @@ import { CanvasBase } from './CanvasBase';
  *  @param {number} options.borderWidthwidth of the border (in px), default 5px
  *  @param {number} options.marginmargin of the border (in px), default 0px
  */
-export class Graticule extends CanvasBase {
+export default class Graticule extends CanvasBase {
     constructor(_ol_control_?: any);
     /**
      * Remove the control from its current map and attach it to the new map.
@@ -24,7 +24,7 @@ export class Graticule extends CanvasBase {
      * @param {_ol_Map_} map Map.
      * @api stable
      */
-    setMap(map: _ol_Map_): void;
+    setMap(map: Map): void;
     /** Get canvas overlay
      */
     getCanvas(): void;

--- a/@types/ol-ext/control/GridReference.d.ts
+++ b/@types/ol-ext/control/GridReference.d.ts
@@ -2,7 +2,7 @@ import { Map as _ol_Map_ } from 'ol';
 import Collection from 'ol/Collection';
 import { Coordinate } from 'ol/coordinate';
 import Feature from 'ol/Feature';
-import { CanvasBase } from './CanvasBase';
+import CanvasBase from './CanvasBase';
 /**
  * Draw a grid reference on the map and add an index.
  *
@@ -21,7 +21,7 @@ import { CanvasBase } from './CanvasBase';
  *  @param {function|undefined} options.indexTitle a function that takes a feature and return the title to display in the index, default the first letter of property option
  *  @param {string} options.filterLabel label to display in the search bar, default 'filter'
  */
-export class GridReference extends CanvasBase {
+export default class GridReference extends CanvasBase {
     constructor(Control?: any);
     /** Returns the text to be displayed in the index
      * @param {Feature} f the feature

--- a/@types/ol-ext/control/Imageline.d.ts
+++ b/@types/ol-ext/control/Imageline.d.ts
@@ -31,7 +31,7 @@ export interface Options {
  *	@param {boolean} options.hover select image on hover, default false
  *	@param {string|boolean} options.linkColor link color or false if no link, default false
  */
-export class Imageline extends ol_control_Control {
+export default class Imageline extends ol_control_Control {
     constructor(options?: Options);
     /**
      * Remove the control from its current map and attach it to the new map.

--- a/@types/ol-ext/control/IsochroneGeoportail.d.ts
+++ b/@types/ol-ext/control/IsochroneGeoportail.d.ts
@@ -40,7 +40,7 @@ export interface Options {
  *
  *  @param {string} options.exclusions Exclusion list separate with a comma 'Toll,Tunnel,Bridge'
  */
-export class IsochroneGeoportail extends ol_control_Control {
+export default class IsochroneGeoportail extends ol_control_Control {
     constructor(options?: Options);
     /**
      * Set the map instance the control is associated with

--- a/@types/ol-ext/control/LayerPopup.d.ts
+++ b/@types/ol-ext/control/LayerPopup.d.ts
@@ -1,6 +1,6 @@
 import { Map as _ol_Map_ } from 'ol';
 import { Layer } from 'ol/layer';
-import { LayerSwitcher } from './LayerSwitcher';
+import LayerSwitcher from './LayerSwitcher';
 /**
  * OpenLayers Layer Switcher Contr
  *
@@ -8,7 +8,7 @@ import { LayerSwitcher } from './LayerSwitcher';
  * @extends {contrLayerSwitcher}
  * @param {Object=} options Control options.
  */
-export class LayerPopup extends LayerSwitcher {
+export default class LayerPopup extends LayerSwitcher {
     constructor(options?: any);
     /** Disable overflow
      */

--- a/@types/ol-ext/control/LayerSwitcher.d.ts
+++ b/@types/ol-ext/control/LayerSwitcher.d.ts
@@ -38,7 +38,7 @@ export interface Options {
  *	- displayInLayerSwitcher {boolean} display in switcher, default true
  *	- noSwitcherDelete {boolean} to prevent layer deletion (w. trash option = true), default false
  */
-export class LayerSwitcher extends ol_control_Control {
+export default class LayerSwitcher extends ol_control_Control {
     constructor(options?: Options);
     /** List of tips for internationalization purposes
      */

--- a/@types/ol-ext/control/LayerSwitcherImage.d.ts
+++ b/@types/ol-ext/control/LayerSwitcherImage.d.ts
@@ -1,6 +1,6 @@
 import { Map as _ol_Map_ } from 'ol';
 import { Layer } from 'ol/layer';
-import { LayerSwitcher } from './LayerSwitcher';
+import LayerSwitcher from './LayerSwitcher';
 /**
  * @classdesc OpenLayers Layer Switcher Contr
  * @require layer.getPreview
@@ -9,7 +9,7 @@ import { LayerSwitcher } from './LayerSwitcher';
  * @extends {contrLayerSwitcher}
  * @param {Object=} options Control options.
  */
-export class LayerSwitcherImage extends LayerSwitcher {
+export default class LayerSwitcherImage extends LayerSwitcher {
     constructor(options?: any);
     /** Render a list of layer
      * @param {elt} element to render

--- a/@types/ol-ext/control/Legend.d.ts
+++ b/@types/ol-ext/control/Legend.d.ts
@@ -28,7 +28,7 @@ export interface Options {
  *  @param { Style | Array<Style> | StyleFunction | undefined	} options.style a style or a style function to use with features
  * @extends {contrControl}
  */
-export class Legend extends ol_control_Control {
+export default class Legend extends ol_control_Control {
     constructor(options: Options);
     /** Set the style
      * @param { Style | Array<Style> | StyleFunction | undefined	} style a style or a style function to use with features

--- a/@types/ol-ext/control/MapZone.d.ts
+++ b/@types/ol-ext/control/MapZone.d.ts
@@ -21,7 +21,7 @@ export interface Options {
  *  @param {Array<any>} options.zone an array of zone: { name, Extent (in EPSG:4326) }
  *  @param {bolean} options.centerOnClick center on click when click on zones, default true
  */
-export class MapZone extends ol_control_Control {
+export default class MapZone extends ol_control_Control {
     constructor(options?: Options);
     /** Set the control visibility
     * @param {boolean} b

--- a/@types/ol-ext/control/Notification.d.ts
+++ b/@types/ol-ext/control/Notification.d.ts
@@ -16,7 +16,7 @@ export interface Options {
  *  @param {boolean} hideOnClick hide the control on click, default false
  *  @param {boolean} closeBox add a closeBox to the control, default false
  */
-export class Notification extends ol_control_Control {
+export default class Notification extends ol_control_Control {
     constructor(options?: Options);
     /**
      * Display a notification on the map

--- a/@types/ol-ext/control/Overlay.d.ts
+++ b/@types/ol-ext/control/Overlay.d.ts
@@ -20,7 +20,7 @@ export interface Options {
  *	@param {bool} options.hideOnClick hide the control on click, default false
  *	@param {bool} options.closeBox add a closeBox to the control, default false
  */
-export class Overlay extends ol_control_Control {
+export default class Overlay extends ol_control_Control {
     constructor(options?: Options);
     /** Set the content of the overlay
     * @param {string|Element} html the html to display in the control

--- a/@types/ol-ext/control/Overview.d.ts
+++ b/@types/ol-ext/control/Overview.d.ts
@@ -33,7 +33,7 @@ export interface Options {
  *  @param {Style | Array.<Style> | undefined} options.style style to draw the map Extent on the overveiw
  *  @param {bool|elastic} options.panAnimation use animation to center map on click, default true
  */
-export class Overview extends ol_control_Control {
+export default class Overview extends ol_control_Control {
     constructor(options?: Options);
     /** Elastic bounce
      *	@param {number} bounce number of bounce

--- a/@types/ol-ext/control/Permalink.d.ts
+++ b/@types/ol-ext/control/Permalink.d.ts
@@ -25,7 +25,7 @@ export interface Options {
  *	@param {bool} options.hidden hide the button on the map, default false
  *	@param {function} options.onclick a function called when control is clicked
  */
-export class Permalink extends ol_control_Control {
+export default class Permalink extends ol_control_Control {
     constructor(options?: Options);
     /**
      * Set the map instance the control associated with.

--- a/@types/ol-ext/control/Print.d.ts
+++ b/@types/ol-ext/control/Print.d.ts
@@ -19,7 +19,7 @@ export interface Options {
  *	@param {number} options.quality Number between 0 and 1 indicating the image quality to use for image formats that use lossy compression such as image/jpeg and image/webp
  *	@param {string} options.orientation Page orientation (landscape/portrait), default guest the best one
  */
-export class Print extends ol_control_Control {
+export default class Print extends ol_control_Control {
     constructor(options?: Options);
     /** Print the map
      * @param {function} cback a callback function that take a string containing the requested data URI.

--- a/@types/ol-ext/control/Profil.d.ts
+++ b/@types/ol-ext/control/Profil.d.ts
@@ -11,7 +11,7 @@ import { Geometry } from 'ol/geom';
  * @param {Object=} _ol_control_ opt_options.
  *
  */
-export class Profil extends ol_control_Control {
+export default class Profil extends ol_control_Control {
     constructor(_ol_control_?: any);
     /** Custom infos list
     * @api stable

--- a/@types/ol-ext/control/RoutingGeoportail.d.ts
+++ b/@types/ol-ext/control/RoutingGeoportail.d.ts
@@ -35,7 +35,7 @@ export interface Options {
  *	@param {function} options.getTitle a function that takes a feature and return the name to display in the index.
  *	@param {function} options.autocomplete a function that take a search string and callback function to send an array
  */
-export class RoutingGeoportail extends ol_control_Control {
+export default class RoutingGeoportail extends ol_control_Control {
     constructor(options?: Options);
     /**
      * Set the map instance the control is associated with

--- a/@types/ol-ext/control/Scale.d.ts
+++ b/@types/ol-ext/control/Scale.d.ts
@@ -19,7 +19,7 @@ export interface Options {
  *  @param {string} options.ppi screen ppi, default 96
  * 	@param {string} options.editable make the control editable, default true
  */
-export class Scale extends ol_control_Control {
+export default class Scale extends ol_control_Control {
     constructor(options?: Options);
     /**
      * Remove the control from its current map and attach it to the new map.

--- a/@types/ol-ext/control/Search.d.ts
+++ b/@types/ol-ext/control/Search.d.ts
@@ -38,7 +38,7 @@ export interface Options {
  *  @param {function} options.getTitle a function that takes a feature and return the name to display in the index.
  *  @param {function} options.autocomplete a function that take a search string and callback function to send an array
  */
-export class Search extends ol_control_Control {
+export default class Search extends ol_control_Control {
     constructor(options?: Options);
     /** Get the input field
     *	@return {Element}

--- a/@types/ol-ext/control/SearchBAN.d.ts
+++ b/@types/ol-ext/control/SearchBAN.d.ts
@@ -1,5 +1,5 @@
 import Feature from 'ol/Feature';
-import { Search } from './Search';
+import Search from './Search';
 /**
  * Search places using the French National Base Address (BAN) API.
  *
@@ -20,7 +20,7 @@ import { Search } from './Search';
  *	@param {function} options.getTitle a function that takes a feature and return the text to display in the menu, default return label attribute
  * @see {@link https://adresse.data.gouv.fr/api/}
  */
-export class SearchBAN extends Search {
+export default class SearchBAN extends Search {
     constructor(Control?: any);
     /** Returns the text to be displayed in the menu
      *	@param {Feature} f the feature

--- a/@types/ol-ext/control/SearchDFCI.d.ts
+++ b/@types/ol-ext/control/SearchDFCI.d.ts
@@ -1,4 +1,4 @@
-import { Search } from './Search';
+import Search from './Search';
 /**
  * Search on DFCI grid.
  *
@@ -18,7 +18,7 @@ import { Search } from './Search';
  *	@param {function} options.getTitle a function that takes a feature and return the name to display in the index, default return the property
  *	@param {function | undefined} options.getSearchString a function that take a feature and return a text to be used as search string, default geTitle() is used as search string
  */
-export class SearchDFCI extends Search {
+export default class SearchDFCI extends Search {
     constructor(Control?: any);
     /** Autocomplete function
     * @param {string} s search string

--- a/@types/ol-ext/control/SearchFeature.d.ts
+++ b/@types/ol-ext/control/SearchFeature.d.ts
@@ -1,6 +1,6 @@
 import Feature from 'ol/Feature';
 import { Vector as VectorSource } from 'ol/source';
-import { Search } from './Search';
+import Search from './Search';
 /**
  * Search features.
  *
@@ -20,7 +20,7 @@ import { Search } from './Search';
  *	@param {function} options.getTitle a function that takes a feature and return the name to display in the index, default return the property
  *	@param {function | undefined} options.getSearchString a function that take a feature and return a text to be used as search string, default geTitle() is used as search string
  */
-export class SearchFeature extends Search {
+export default class SearchFeature extends Search {
     constructor(Control?: any);
     /** No history avaliable on features
      */

--- a/@types/ol-ext/control/SearchGPS.d.ts
+++ b/@types/ol-ext/control/SearchGPS.d.ts
@@ -1,4 +1,4 @@
-import { Search } from './Search';
+import Search from './Search';
 /**
  * Search on GPS coordinate.
  *
@@ -14,7 +14,7 @@ import { Search } from './Search';
  *  @param {number | undefined} options.minLength minimum length to start searching, default 1
  *  @param {number | undefined} options.maxItems maximum number of items to display in the autocomplete list, default 10
  */
-export class SearchGPS extends Search {
+export default class SearchGPS extends Search {
     constructor(Control?: any);
     /** Autocomplete function
     * @param {string} s search string

--- a/@types/ol-ext/control/SearchGeoportail.d.ts
+++ b/@types/ol-ext/control/SearchGeoportail.d.ts
@@ -1,5 +1,5 @@
 import Feature from 'ol/Feature';
-import { SearchJSON } from './SearchJSON';
+import SearchJSON from './SearchJSON';
 import { AddressType } from './control';
 
 export interface Options {
@@ -34,7 +34,7 @@ export interface Options {
  *	@param {StreetAddress|PositionOfInterest|CadastralParcel|Commune} options.type type of search. Using Commune will return the INSEE code, default StreetAddress,PositionOfInterest
  * @see {@link https://geoservices.ign.fr/documentation/geoservices/geocodage.html}
  */
-export class SearchGeoportail extends SearchJSON {
+export default class SearchGeoportail extends SearchJSON {
     constructor(options: Options);
     /** Returns the text to be displayed in the menu
      *	@param {Feature} f the feature

--- a/@types/ol-ext/control/SearchGeoportailParcelle.d.ts
+++ b/@types/ol-ext/control/SearchGeoportailParcelle.d.ts
@@ -1,4 +1,4 @@
-import { SearchJSON } from './SearchJSON';
+import SearchJSON from './SearchJSON';
 
 export interface Options {
     className: string;
@@ -32,7 +32,7 @@ export interface Options {
  *	@param {Number} options.pageSize item per page for parcelle list paging, use -1 for no paging, default 5
  * @see {@link https://geoservices.ign.fr/documentation/geoservices/geocodage.html}
  */
-export class SearchGeoportailParcelle extends SearchJSON {
+export default class SearchGeoportailParcelle extends SearchJSON {
     constructor(options: Options);
     /** Set the input parcelle
      * @param {*} p parcel

--- a/@types/ol-ext/control/SearchJSON.d.ts
+++ b/@types/ol-ext/control/SearchJSON.d.ts
@@ -1,4 +1,4 @@
-import { Search } from './Search';
+import Search from './Search';
 
 export interface Options {
     className: string;
@@ -32,7 +32,7 @@ export interface Options {
  *	@param {string|undefined} options.url Url of the search api
  *	@param {string | undefined} options.authentication: basic authentication for the search API as btoa("login:pwd")
  */
-export class SearchJSON extends Search {
+export default class SearchJSON extends Search {
     constructor(options: Options);
     /** Autocomplete function (ajax request to the server)
     * @param {string} s search string

--- a/@types/ol-ext/control/SearchNominatim.d.ts
+++ b/@types/ol-ext/control/SearchNominatim.d.ts
@@ -1,5 +1,5 @@
 import Feature from 'ol/Feature';
-import { Search } from './Search';
+import Search from './Search';
 /**
  * Search places using the Nominatim geocoder from the OpenStreetmap project.
  *
@@ -20,7 +20,7 @@ import { Search } from './Search';
  *	@param {string|undefined} options.url URL to Nominatim API, default "https://nominatim.openstreetmap.org/search"
  * @see {@link https://wiki.openstreetmap.org/wiki/Nominatim}
  */
-export class SearchNominatim extends Search {
+export default class SearchNominatim extends Search {
     constructor(Control?: any);
     /** Returns the text to be displayed in the menu
      *	@param {Feature} f the feature

--- a/@types/ol-ext/control/SearchPhoton.d.ts
+++ b/@types/ol-ext/control/SearchPhoton.d.ts
@@ -1,5 +1,5 @@
 import Feature from 'ol/Feature';
-import { SearchJSON } from './SearchJSON';
+import SearchJSON from './SearchJSON';
 /**
  * Search places using the photon API.
  *
@@ -21,7 +21,7 @@ import { SearchJSON } from './SearchJSON';
  *	@param {boolean} options.position Search, with priority to geo position, default false
  *	@param {function} options.getTitle a function that takes a feature and return the name to display in the index, default return street + name + contry
  */
-export class SearchPhoton extends SearchJSON {
+export default class SearchPhoton extends SearchJSON {
     constructor(Control?: any);
     /** Returns the text to be displayed in the menu
     *	@param {Feature} f the feature

--- a/@types/ol-ext/control/SearchWikipedia.d.ts
+++ b/@types/ol-ext/control/SearchWikipedia.d.ts
@@ -1,5 +1,5 @@
 import Feature from 'ol/Feature';
-import { SearchJSON } from './SearchJSON';
+import SearchJSON from './SearchJSON';
 /**
  * Search places using the MediaWiki API.
  * @see https://www.mediawiki.org/wiki/API:Main_page
@@ -19,7 +19,7 @@ import { SearchJSON } from './SearchJSON';
  *
  *  @param {string|undefined} options.lang API language, default none
  */
-export class SearchWikipedia extends SearchJSON {
+export default class SearchWikipedia extends SearchJSON {
     constructor(Control?: any);
     /** Returns the text to be displayed in the menu
     *	@param {Feature} f the feature

--- a/@types/ol-ext/control/Select.d.ts
+++ b/@types/ol-ext/control/Select.d.ts
@@ -1,7 +1,7 @@
 import Collection from 'ol/Collection';
 import Feature from 'ol/Feature';
 import { Vector as VectorSource } from 'ol/source';
-import { SelectBase } from './SelectBase';
+import SelectBase from './SelectBase';
 import { condition } from './control';
 
 export interface Options {
@@ -33,7 +33,7 @@ export interface Options {
  *  @param {string} [options.attrPlaceHolder=attribute]
  *  @param {string} [options.valuePlaceHolder=value]
  */
-export class Select extends SelectBase {
+export default class Select extends SelectBase {
     constructor(options?: Options);
     /** Add a new condition
      * @param {*} options

--- a/@types/ol-ext/control/SelectBase.d.ts
+++ b/@types/ol-ext/control/SelectBase.d.ts
@@ -24,7 +24,7 @@ export interface Options {
  *  @param {Collection<Feature>} options.features a collection of feature to search in, the collection will be kept in date while selection
  *  @param {Vector | Array<Vector>} options.source the source to search in if no features set
  */
-export class SelectBase extends ol_control_Control {
+export default class SelectBase extends ol_control_Control {
     constructor(options?: Options);
     /** Set the current sources
      * @param {VectorSource|Array<VectorSource>|undefined} source

--- a/@types/ol-ext/control/SelectCheck.d.ts
+++ b/@types/ol-ext/control/SelectCheck.d.ts
@@ -2,7 +2,7 @@ import { Map as _ol_Map_ } from 'ol';
 import Collection from 'ol/Collection';
 import Feature from 'ol/Feature';
 import { Vector as VectorSource } from 'ol/source';
-import { SelectBase } from './SelectBase';
+import SelectBase from './SelectBase';
 import { condition } from './control';
 
 export interface Options {
@@ -35,7 +35,7 @@ export interface Options {
  *  @param {number} options.defaultLabel label for the default radio button
  *  @param {function|undefined} options.onchoice function triggered when an option is clicked, default doSelect
  */
-export class SelectCheck extends SelectBase {
+export default class SelectCheck extends SelectBase {
     constructor(options?: Options);
     /**
     * Set the map instance the control associated with.

--- a/@types/ol-ext/control/SelectCondition.d.ts
+++ b/@types/ol-ext/control/SelectCondition.d.ts
@@ -1,7 +1,7 @@
 import Collection from 'ol/Collection';
 import Feature from 'ol/Feature';
 import { Vector as VectorSource } from 'ol/source';
-import { SelectBase } from './SelectBase';
+import SelectBase from './SelectBase';
 import { condition } from './control';
 
 export interface Options {
@@ -28,7 +28,7 @@ export interface Options {
  *  @param {condition|Array<condition>} options.condition conditions
  *  @param {function|undefined} options.onchoice function triggered when an option is clicked, default doSelect
  */
-export class SelectCondition extends SelectBase {
+export default class SelectCondition extends SelectBase {
     constructor(options?: Options);
     /** Set condition to select on
      * @param {condition, Array<condition>} condition

--- a/@types/ol-ext/control/SelectFulltext.d.ts
+++ b/@types/ol-ext/control/SelectFulltext.d.ts
@@ -1,7 +1,7 @@
 import Collection from 'ol/Collection';
 import Feature from 'ol/Feature';
 import { Vector as VectorSource } from 'ol/source';
-import { SelectBase } from './SelectBase';
+import SelectBase from './SelectBase';
 import { condition } from './control';
 
 export interface Options {
@@ -24,7 +24,7 @@ export interface Options {
  *  @param {string} options.property property to select on
  *  @param {function|undefined} options.onchoice function triggered the text change, default nothing
  */
-export class SelectFulltext extends SelectBase {
+export default class SelectFulltext extends SelectBase {
     constructor(options?: Options);
     /** Select features by condition
      */

--- a/@types/ol-ext/control/SelectMulti.d.ts
+++ b/@types/ol-ext/control/SelectMulti.d.ts
@@ -2,7 +2,7 @@ import { Map as _ol_Map_ } from 'ol';
 import Collection from 'ol/Collection';
 import Feature from 'ol/Feature';
 import { Vector as VectorSource } from 'ol/source';
-import { SelectBase } from './SelectBase';
+import SelectBase from './SelectBase';
 import { condition } from './control';
 
 export interface Options {
@@ -24,7 +24,7 @@ export interface Options {
  *  @param {Vector | Array<Vector>} options.source the source to search in
  *  @param {Array<contrSelectBase>} options.controls an array of controls
  */
-export class SelectMulti extends SelectBase {
+export default class SelectMulti extends SelectBase {
     constructor(options?: Options);
     /**
     * Set the map instance the control associated with.

--- a/@types/ol-ext/control/SelectPopup.d.ts
+++ b/@types/ol-ext/control/SelectPopup.d.ts
@@ -2,7 +2,7 @@ import { Map as _ol_Map_ } from 'ol';
 import Collection from 'ol/Collection';
 import Feature from 'ol/Feature';
 import { Vector as VectorSource } from 'ol/source';
-import { SelectBase } from './SelectBase';
+import SelectBase from './SelectBase';
 import { condition } from './control';
 
 export interface Options {
@@ -31,7 +31,7 @@ export interface Options {
  *  @param {string} options.defaultLabel label for the default selection
  *  @param {function|undefined} options.onchoice function triggered when an option is clicked, default doSelect
  */
-export class SelectPopup extends SelectBase {
+export default class SelectPopup extends SelectBase {
     constructor(options?: Options);
     /**
     * Set the map instance the control associated with.

--- a/@types/ol-ext/control/Swipe.d.ts
+++ b/@types/ol-ext/control/Swipe.d.ts
@@ -13,7 +13,7 @@ import { Layer } from 'ol/layer';
  *	@param {number} options.position position propertie of the swipe [0,1], default 0.5
  *	@param {string} options.orientation orientation propertie (vertical|horizontal), default vertical
  */
-export class Swipe extends ol_control_Control {
+export default class Swipe extends ol_control_Control {
     constructor(Control?: any);
     /**
      * Set the map instance the control associated with.

--- a/@types/ol-ext/control/Target.d.ts
+++ b/@types/ol-ext/control/Target.d.ts
@@ -1,6 +1,6 @@
 import { Map as _ol_Map_ } from 'ol';
 import { Style } from 'ol/style';
-import { CanvasBase } from './CanvasBase';
+import CanvasBase from './CanvasBase';
 
 export interface Options {
     style: Style | Style[];
@@ -13,7 +13,7 @@ export interface Options {
  *  @param {Style|Array<Style>} options.style
  *  @param {string} options.composite composite operation = difference|multiply|xor|screen|overlay|darken|lighter|lighten|...
  */
-export class Target extends CanvasBase {
+export default class Target extends CanvasBase {
     constructor(options: Options);
     /** Set the control visibility
      * @paraam {boolean} b

--- a/@types/ol-ext/control/TextButton.d.ts
+++ b/@types/ol-ext/control/TextButton.d.ts
@@ -1,4 +1,4 @@
-import { Button } from './Button';
+import Button from './Button';
 
 export interface Options {
     className: string;
@@ -15,7 +15,7 @@ export interface Options {
  *	@param {String} options.html html to insert in the control
  *	@param {function} options.handleClick callback when control is clicked (or use change:active event)
  */
-export class TextButton extends Button {
+export default class TextButton extends Button {
     constructor(options?: Options);
     /** Set the control visibility
     * @param {boolean} b

--- a/@types/ol-ext/control/Timeline.d.ts
+++ b/@types/ol-ext/control/Timeline.d.ts
@@ -44,7 +44,7 @@ export interface Options {
  *	@param {String} options.graduation day|month to show month or day graduation, default show only years
  *	@param {String} options.scrollTimeout Time in milliseconds to get a scroll event, default 15ms
  */
-export class Timeline extends ol_control_Control {
+export default class Timeline extends ol_control_Control {
     constructor(options?: Options);
     /**
      * Set the map instance the control is associated with

--- a/@types/ol-ext/control/Toggle.d.ts
+++ b/@types/ol-ext/control/Toggle.d.ts
@@ -1,7 +1,7 @@
 import { Map as _ol_Map_ } from 'ol';
 import ol_control_Control from 'ol/control/Control';
 import { Interaction } from 'ol/interaction';
-import { Bar } from './Bar';
+import Bar from './Bar';
 
 export interface Options {
     className: string;
@@ -31,7 +31,7 @@ export interface Options {
  *	@param {bool} options.autoActive the control will activate when shown in an contrBar, default false
  *	@param {function} options.onToggle callback when control is clicked (or use change:active event)
  */
-export class Toggle extends ol_control_Control {
+export default class Toggle extends ol_control_Control {
     constructor(options?: Options);
     /**
      * Set the map instance the control is associated with

--- a/@types/ol-ext/featureanimation/Bounce.d.ts
+++ b/@types/ol-ext/featureanimation/Bounce.d.ts
@@ -1,4 +1,4 @@
-import { featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
+import { default as featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
 
 export interface Options {
     bounce?: number;
@@ -17,10 +17,12 @@ export interface Options {
  *	@param {easing} options.easing easing used for decaying amplitude, use function(){return 0} for no decay, default easing.linear
  *	@param {number} options.duration duration in ms, default 1000
  */
-export class Bounce extends featureAnimation {
+declare class Bounce extends featureAnimation {
     constructor(options?: Options)
     /** Animate
     * @param {FeatureAnimationEvent} e
      */
     animate(e: FeatureAnimationEvent): boolean;
 }
+
+export default Bounce;

--- a/@types/ol-ext/featureanimation/Drop.d.ts
+++ b/@types/ol-ext/featureanimation/Drop.d.ts
@@ -1,4 +1,4 @@
-import { featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
+import { default as featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
 
 export interface Options{
     speed?: number;
@@ -12,10 +12,12 @@ export interface Options{
  *  @param {Number} options.speed speed of the feature if 0 the duration parameter will be used instead, default 0
  *  @param {Number} options.side top or bottom, default top
  */
-export class Drop extends featureAnimation {
+declare class Drop extends featureAnimation {
     constructor(options?: Options)
     /** Animate
     * @param {FeatureAnimationEvent} e
      */
     animate(e: FeatureAnimationEvent): boolean;
 }
+
+export default Drop;

--- a/@types/ol-ext/featureanimation/Fade.d.ts
+++ b/@types/ol-ext/featureanimation/Fade.d.ts
@@ -1,13 +1,15 @@
-import { featureAnimation, FeatureAnimationEvent, Options } from './FeatureAnimation';
+import { default as featureAnimation, FeatureAnimationEvent, Options } from './FeatureAnimation';
 /** Fade animation: feature fade in
  * @constructor
  * @extends {featureAnimation}
  * @param {featureAnimationOptions} options
  */
-export class Fade extends featureAnimation {
+declare class Fade extends featureAnimation {
     constructor(options?: Options);
     /** Animate
     * @param {featureAnimationEvent} e
      */
     animate(e: FeatureAnimationEvent): boolean;
 }
+
+export default Fade;

--- a/@types/ol-ext/featureanimation/None.d.ts
+++ b/@types/ol-ext/featureanimation/None.d.ts
@@ -1,14 +1,16 @@
-import { featureAnimation, FeatureAnimationEvent, Options } from './FeatureAnimation';
+import { default as featureAnimation, FeatureAnimationEvent, Options } from './FeatureAnimation';
 /** Do nothing for a given duration
  * @constructor
  * @extends {featureAnimation}
  * @param {featureAnimationShowOptions} options
  *
  */
-export class None extends featureAnimation {
+declare class None extends featureAnimation {
     constructor(options?: Options);
     /** Animate: do nothing during the laps time
     * @param {featureAnimationEvent} e
      */
     animate(e: FeatureAnimationEvent): boolean;
 }
+
+export default None;

--- a/@types/ol-ext/featureanimation/Null.d.ts
+++ b/@types/ol-ext/featureanimation/Null.d.ts
@@ -1,9 +1,9 @@
-import { featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
+import { default as featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
 /** Do nothing
  * @constructor
  * @extends {featureAnimation}
  */
-export class Null extends featureAnimation {
+declare class Null extends featureAnimation {
     /** Function to perform manipulations onpostcompose.
      * This function is called with an featureAnimationEvent argument.
      * The function will be overridden by the child implementation.
@@ -14,3 +14,5 @@ export class Null extends featureAnimation {
      */
     animate(e: FeatureAnimationEvent): boolean;
 }
+
+export default Null;

--- a/@types/ol-ext/featureanimation/Path.d.ts
+++ b/@types/ol-ext/featureanimation/Path.d.ts
@@ -1,6 +1,6 @@
 import Feature from 'ol/Feature';
 import { LineString } from 'ol/geom';
-import { featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
+import { default as featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
 
 export interface Options{
     speed?: number;
@@ -15,10 +15,12 @@ export interface Options{
  *  @param {Number|boolean} options.rotate rotate the symbol when following the path, true or the initial rotation, default false
  *  @param {LineString|Feature} options.path the path to follow
  */
-export class Path extends featureAnimation {
+declare class Path extends featureAnimation {
     constructor(options? : Options)
     /** Animate
     * @param {FeatureAnimationEvent} e
      */
     animate(e: FeatureAnimationEvent): boolean;
 }
+
+export default Path;

--- a/@types/ol-ext/featureanimation/Shake.d.ts
+++ b/@types/ol-ext/featureanimation/Shake.d.ts
@@ -1,4 +1,4 @@
-import { featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
+import { default as featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
 
 export interface Options{
     bounce?: number;
@@ -13,10 +13,12 @@ export interface Options{
  *	@param {number} options.amplitude amplitude of the animation, default 40
  *	@param {bool} options.horizontal shake horizontally default false (vertical)
  */
-export class Shake extends featureAnimation {
+declare class Shake extends featureAnimation {
     constructor(options?: Options)
     /** Animate
     * @param {featureAnimationEvent} e
      */
     animate(e: FeatureAnimationEvent): boolean;
 }
+
+export default Shake;

--- a/@types/ol-ext/featureanimation/Show.d.ts
+++ b/@types/ol-ext/featureanimation/Show.d.ts
@@ -1,13 +1,15 @@
-import { featureAnimation, Options, FeatureAnimationEvent } from './FeatureAnimation';
+import { default as featureAnimation, Options, FeatureAnimationEvent } from './FeatureAnimation';
 /** Show an object for a given duration
  * @constructor
  * @extends {featureAnimation}
  * @param {Options} options
  */
-export class Show extends featureAnimation {
+declare class Show extends featureAnimation {
     constructor(options?: Options);
     /** Animate: just show the object during the laps time
     * @param {FeatureAnimationEvent} e
      */
     animate(e: FeatureAnimationEvent): boolean;
 }
+
+export default Show;

--- a/@types/ol-ext/featureanimation/Slide.d.ts
+++ b/@types/ol-ext/featureanimation/Slide.d.ts
@@ -1,4 +1,4 @@
-import { featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
+import { default as featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
 
 export interface Options{
     speed?: number;
@@ -9,10 +9,12 @@ export interface Options{
  * @param {featureAnimationSlideOptions} options
  *  @param {Number} options.speed speed of the animation, if 0 the duration parameter will be used instead, default 0
  */
-export class Slide extends featureAnimation {
+declare class Slide extends featureAnimation {
     constructor(options: Options)
     /** Animate
     * @param {featureAnimationEvent} e
      */
     animate(e: FeatureAnimationEvent): boolean;
 }
+
+export default Slide;

--- a/@types/ol-ext/featureanimation/Teleport.d.ts
+++ b/@types/ol-ext/featureanimation/Teleport.d.ts
@@ -1,13 +1,15 @@
-import { featureAnimation, Options, FeatureAnimationEvent } from './FeatureAnimation';
+import { default as featureAnimation, Options, FeatureAnimationEvent } from './FeatureAnimation';
 /** Teleport a feature at a given place
  * @constructor
  * @extends {featureAnimation}
  * @param {featureAnimationOptions} options
  */
-export class Teleport extends featureAnimation {
+declare class Teleport extends featureAnimation {
     constructor(options?: Options);
     /** Animate
     * @param {FeatureAnimationEvent} e
      */
     animate(e: FeatureAnimationEvent): boolean;
 }
+
+export default Teleport;

--- a/@types/ol-ext/featureanimation/Throw.d.ts
+++ b/@types/ol-ext/featureanimation/Throw.d.ts
@@ -1,4 +1,4 @@
-import { featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
+import { default as featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
 
 export interface Options {
     side?: 'left' | 'right';
@@ -9,10 +9,12 @@ export interface Options {
  * @param {featureAnimationThrowOptions} options
  *  @param {left|right} options.side side of the animation, default left
  */
-export class Throw extends featureAnimation {
+declare class Throw extends featureAnimation {
     constructor(options?: Options)
     /** Animate
     * @param {FeatureAnimationEvent} e
      */
     animate(e: FeatureAnimationEvent): boolean;
 }
+
+export default Throw;

--- a/@types/ol-ext/featureanimation/Zoom.d.ts
+++ b/@types/ol-ext/featureanimation/Zoom.d.ts
@@ -1,4 +1,4 @@
-import { featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
+import { default as featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
 
 export interface Options {
     zoomOut?: boolean;
@@ -10,10 +10,12 @@ export interface Options {
  * @param {featureAnimationZoomOptions} options
  *  @param {bool} options.zoomOut to zoom out
  */
-export class Zoom extends featureAnimation {
+declare class Zoom extends featureAnimation {
     constructor(options?: Options);
     /** Animate
     * @param {featureAnimationEvent} e
      */
     animate(e: FeatureAnimationEvent): boolean;
 }
+
+export default Zoom;

--- a/@types/ol-ext/featureanimation/ZoomOut.d.ts
+++ b/@types/ol-ext/featureanimation/ZoomOut.d.ts
@@ -1,4 +1,4 @@
-import { featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
+import { default as featureAnimation, FeatureAnimationEvent } from './FeatureAnimation';
 
 export interface Options {
     zoomOut?: boolean;
@@ -8,7 +8,7 @@ export interface Options {
  * @constructor
  * @extends {featureAnimation}
  */
-export class ZoomOut extends featureAnimation {
+declare class ZoomOut extends featureAnimation {
     constructor(options?: Options)
     /** Function to perform manipulations onpostcompose.
      * This function is called with an featureAnimationEvent argument.
@@ -20,3 +20,5 @@ export class ZoomOut extends featureAnimation {
      */
     animate(e: FeatureAnimationEvent): boolean;
 }
+
+export default ZoomOut;

--- a/@types/ol-ext/featureanimation/featureAnimation.d.ts
+++ b/@types/ol-ext/featureanimation/featureAnimation.d.ts
@@ -48,7 +48,7 @@ export interface Options {
 *	@param {easing.Function} options.fade an easing function used to fade in the feature, default none
 *	@param {easing.Function} options.easing an easing function for the animation, default easing.linear
  */
-export class featureAnimation {
+declare class featureAnimation {
     constructor(options?: Options);
     /** Function to perform manipulations onpostcompose.
      * This function is called with an featureAnimationEvent argument.
@@ -61,3 +61,4 @@ export class featureAnimation {
     animate(e: FeatureAnimationEvent): boolean;
 }
 
+export default featureAnimation;

--- a/@types/ol-ext/filter/Base.d.ts
+++ b/@types/ol-ext/filter/Base.d.ts
@@ -1,3 +1,41 @@
+declare module 'ol/Map' {
+    export default interface Map {
+        /** Add a filter to a Map
+         *	@param {filter}
+         */
+        addFilter(filter: Base): void;
+
+        /** Remove a filter to a Map
+         *	@param {filter}
+         */
+        removeFilter(filter: Base): void;
+
+        /** Get filters associated with a Map
+         *	@return {Array<filter>}
+         */
+        getFilters(): Base[];
+    }
+}
+
+declare module 'ol/layer/Layer' {
+    export default interface Layer {
+        /** Add a filter to an ol.Layer
+         *	@param {filter}
+         */
+        addFilter(filter: Base): void;
+
+        /** Remove a filter to an ol.Layer
+         *	@param {filter}
+         */
+        removeFilter(filter: Base): void;
+
+        /** Get filters associated with an ol.Layer
+         *	@return {Array<filter>}
+         */
+        getFilters(): Base[];
+    }
+}
+
 /** Filters are effects that render over a map or a layer.
  * Use the map methods to add or remove filter on a map
  * ({@link Map#addFilter}, {@link Map#removeFilter}, {@link Map#getFilters}).
@@ -22,7 +60,7 @@
  * @param {Object} options Extend {@link _ol_control_Control_} options.
  *  @param {boolean} [options.active]
  */
-export abstract class Base extends Object {
+declare abstract class Base extends Object {
     constructor(options: Options);
     /** Activate / deactivate filter
     *	@param {boolean} b
@@ -33,15 +71,5 @@ export abstract class Base extends Object {
      */
     getActive(): boolean;
 }
-/** Add a filter to an Map
-*	@param {filter}
- */
-export function addFilter(filter: Base): void;
-/** Remove a filter to an Map
-*	@param {filter}
- */
-export function removeFilter(filter: Base): void;
-/** Get filters associated with an Map
-*	@return {Array<filter>}
- */
-export function getFilters(): Base[];
+
+export default Base;

--- a/@types/ol-ext/filter/Clip.d.ts
+++ b/@types/ol-ext/filter/Clip.d.ts
@@ -1,6 +1,6 @@
 import { Coordinate } from 'ol/coordinate';
 import { Extent } from 'ol/extent';
-import { Base } from './Base';
+import Base from './Base';
 
 export interface Options {
     coords?: Coordinate[];
@@ -20,7 +20,7 @@ export interface Options {
 *  @param {boolean} [options.keepAspectRatio] keep aspect ratio
 *  @param {string} [options.color] backgroundcolor
  */
-export class Clip extends Base {
+declare class Clip extends Base {
     constructor(options?: Options);
     /** Activate / deactivate filter
     *	@param {boolean} b
@@ -31,3 +31,5 @@ export class Clip extends Base {
      */
     getActive(): boolean;
 }
+
+export default Clip;

--- a/@types/ol-ext/filter/Colorize.d.ts
+++ b/@types/ol-ext/filter/Colorize.d.ts
@@ -1,4 +1,4 @@
-import { Base } from './Base';
+import Base from './Base';
 import { ColorLike } from 'ol/colorlike';
 
 
@@ -24,9 +24,7 @@ export declare type FilterColorizeOptions = {
  * @author Jean-Marc Viglino https://github.com/viglino
  * @param {FilterColorizeOptions} options
  */
-
-
-export class Colorize extends Base {
+declare class Colorize extends Base {
     constructor(options: FilterColorizeOptions);
     /** Set options to the filter
      * @param {FilterColorizeOptions} [options]
@@ -49,3 +47,5 @@ export class Colorize extends Base {
      */
     getActive(): boolean;
 }
+
+export default Colorize;

--- a/@types/ol-ext/filter/Composite.d.ts
+++ b/@types/ol-ext/filter/Composite.d.ts
@@ -1,4 +1,4 @@
-import { Base } from './Base';
+import Base from './Base';
 
 export interface Options {
     operation: string;
@@ -10,7 +10,7 @@ export interface Options {
 * @param {Object} options
 *   @param {string} options.operation composite operation
  */
-export class Composite extends Base {
+declare class Composite extends Base {
     constructor(options: Options);
     /** Change the current operation
     *	@param {string} operation composite function
@@ -25,3 +25,5 @@ export class Composite extends Base {
      */
     getActive(): boolean;
 }
+
+export default Composite;

--- a/@types/ol-ext/filter/Crop.d.ts
+++ b/@types/ol-ext/filter/Crop.d.ts
@@ -1,5 +1,5 @@
 import Feature from 'ol/Feature';
-import { Mask } from './Mask';
+import Mask from './Mask';
 
 export interface Options {
     feature?: Feature;
@@ -14,7 +14,7 @@ export interface Options {
 *  @param {Feature} [options.feature] feature to crop with
 *  @param {boolean} [options.inner=false] mask inner, default false
  */
-export class Crop extends Mask {
+declare class Crop extends Mask {
     constructor(options?: Options);
     /** Draw the feature into canvas
      */
@@ -28,3 +28,5 @@ export class Crop extends Mask {
      */
     getActive(): boolean;
 }
+
+export default Crop;

--- a/@types/ol-ext/filter/Fold.d.ts
+++ b/@types/ol-ext/filter/Fold.d.ts
@@ -1,4 +1,4 @@
-import { Base } from './Base';
+import Base from './Base';
 
 export interface Options {
     margin?: number;
@@ -15,7 +15,7 @@ export interface Options {
 *  @param {number} [options.padding] padding in px, default 8
 *  @param {number|number[]} [options.fSize] fold Size in px, default 8,10
  */
-export class Fold extends Base {
+declare class Fold extends Base {
     constructor(options?: Options);
     /** Activate / deactivate filter
     *	@param {boolean} b
@@ -26,3 +26,5 @@ export class Fold extends Base {
      */
     getActive(): boolean;
 }
+
+export default Fold;

--- a/@types/ol-ext/filter/Lego.d.ts
+++ b/@types/ol-ext/filter/Lego.d.ts
@@ -1,4 +1,4 @@
-import { Base } from './Base';
+import Base from './Base';
 
 export interface Options { 
     img?: string;
@@ -14,7 +14,7 @@ export interface Options {
  *  @param {number} [options.brickSize] Size of te brick, default 30
  *  @param {null | string | undefined} [options.crossOrigin] crossOrigin attribute for loaded images.
  */
-export class Lego extends Base {
+declare class Lego extends Base {
     constructor(options?: Options);
     /** Image definition
      */
@@ -47,3 +47,5 @@ export class Lego extends Base {
      */
     getActive(): boolean;
 }
+
+export default Lego;

--- a/@types/ol-ext/filter/Mask.d.ts
+++ b/@types/ol-ext/filter/Mask.d.ts
@@ -1,6 +1,6 @@
 import Feature from 'ol/Feature';
 import { Fill } from 'ol/style';
-import { Base } from './Base';
+import Base from './Base';
 
 export interface Options {
     feature?: Feature;
@@ -16,7 +16,7 @@ export interface Options {
  *  @param {Fill} [options.fill] style to fill with
  *  @param {boolean} [options.inner] mask inner, default false
  */
-export class Mask extends Base {
+declare class Mask extends Base {
     constructor(options?: Options);
     /** Draw the feature into canvas
      */
@@ -30,3 +30,5 @@ export class Mask extends Base {
      */
     getActive(): boolean;
 }
+
+export default Mask;

--- a/@types/ol-ext/filter/Texture.d.ts
+++ b/@types/ol-ext/filter/Texture.d.ts
@@ -1,4 +1,4 @@
-import { Base } from './Base';
+import Base from './Base';
 import {Image} from 'ol/style';
 
 /** @typedef {Object} FilterTextureOptions
@@ -25,7 +25,7 @@ export declare type FilterTextureOptions = {
  * @extends {filter.Base}
  * @param {FilterTextureOptions} options
  */
-export class Texture extends Base {
+declare class Texture extends Base {
     constructor(options: FilterTextureOptions);
     /** Set texture
      * @param {FilterTextureOptions} [options]
@@ -48,3 +48,5 @@ export class Texture extends Base {
      */
     getActive(): boolean;
 }
+
+export default Texture;

--- a/@types/ol-ext/geom/ConvexHull.d.ts
+++ b/@types/ol-ext/geom/ConvexHull.d.ts
@@ -6,4 +6,6 @@ import Projection from 'ol/proj/Projection';
    * @param {Array<Point>} points an array of 2D points
    * @return {Array<Point>} the confvex hull vertices
    */
-export function convexHull(points: Geometry[]): Point[];
+declare function convexHull(points: Geometry[]): Point[];
+
+export default convexHull;

--- a/@types/ol-ext/geom/DFCI.d.ts
+++ b/@types/ol-ext/geom/DFCI.d.ts
@@ -6,22 +6,22 @@ import { ProjectionLike } from 'ol/proj';
  * @param {Projection} projection of the coord, default EPSG:27572
  * @return {String} the DFCI index
  */
-export function toDFCI(coord: Coordinate, level: number, projection: ProjectionLike): string;
+export function ol_coordinate_toDFCI(coord: Coordinate, level: number, projection: ProjectionLike): string;
 /** Get coordinate from French DFCI index
    * @param {String} index the DFCI index
    * @param {Projection} projection result projection, default EPSG:27572
    * @return {Coordinate} coord
    */
-export function fromDFCI(index: string, projection: ProjectionLike): Coordinate;
+export function ol_coordinate_fromDFCI(index: string, projection: ProjectionLike): Coordinate;
 /** The string is a valid DFCI index
  * @param {string} index DFCI index
  * @return {boolean}
  */
-export function validDFCI(index: string): boolean;
+export function ol_coordinate_validDFCI(index: string): boolean;
 
 /** Coordinate is valid for DFCI
  * @param {Coordinate} coord
  * @param {Projection} projection result projection, default EPSG:27572
  * @return {boolean}
  */
-export function validDFCICoord(coord: Coordinate, projection: ProjectionLike): boolean;
+export function ol_coordinate_validDFCICoord(coord: Coordinate, projection: ProjectionLike): boolean;

--- a/@types/ol-ext/geom/Dijskra.d.ts
+++ b/@types/ol-ext/geom/Dijskra.d.ts
@@ -32,7 +32,7 @@ import { Vector as VectorSource } from 'ol/source';
  *  @param {number} [options.stepIteration=2000] number of iterations before a calculating event is fired, default 2000
  *  @param {number} [options.epsilon=1E-6] geometric precision (min distance beetween 2 points), default 1E-6
  */
-export class Dijskra {
+declare class Dijskra {
     constructor(options: Options);
     /** Get the weighting of the edge, for example a speed factor
      * The function returns a value beetween ]0,1]
@@ -93,3 +93,5 @@ export class Dijskra {
      */
     getBestWay(): Feature[];
 }
+
+export default Dijskra;

--- a/@types/ol-ext/geom/GeomUtils.d.ts
+++ b/@types/ol-ext/geom/GeomUtils.d.ts
@@ -1,29 +1,39 @@
 import { Coordinate } from 'ol/coordinate';
-import Feature from 'ol/Feature'
+import Feature from 'ol/Feature';
+import {Geometry} from 'ol/geom';
+import GeometryType from 'ol/geom/GeometryType';
+
+/** Create a geometry given a type and coordinates
+ * @param {ol.geom.GeometryType} type the geometry type
+ * @param {ol.Coordinate[]|number[]} coordinates the geometry coordinates
+ * @return {ol.geom.Geometry} the geometry
+ */
+export function ol_geom_createFromType(type: GeometryType, coordinates: Coordinate[] | number[]): Geometry;
+
 /** Distance beetween 2 points
 *	Useful geometric functions
 * @param {ol.Coordinate} p1 first point
 * @param {ol.Coordinate} p2 second point
 * @return {number} distance
 */
-export function dist2d(p1: Coordinate, p2: Coordinate): number;
+export function ol_coordinate_dist2d(p1: Coordinate, p2: Coordinate): number;
 /** 2 points are equal
    * Useful geometric functions
    * @param {Coordinate} p1 first point
    * @param {Coordinate} p2 second point
    * @return {boolean}
     */
-export function equal(p1: Coordinate, p2: Coordinate): boolean;
+export function ol_coordinate_equal(p1: Coordinate, p2: Coordinate): boolean;
 /** Get center coordinate of a feature
 * @param {Feature} f
 * @return {Coordinate} the center
  */
-export function getFeatureCenter(f: Feature): Coordinate;
+export function ol_coordinate_getFeatureCenter(f: Feature): Coordinate;
 /** Get center coordinate of a geometry
 * @param {Feature} geom
 * @return {Coordinate} the center
  */
-export function getGeomCenter(geom: Feature): Coordinate;
+export function ol_coordinate_getGeomCenter(geom: Feature): Coordinate;
 /** Offset a polyline
  * @param {Array<Coordinate>} coords
  * @param {number} offset
@@ -31,13 +41,13 @@ export function getGeomCenter(geom: Feature): Coordinate;
  * @see http://stackoverflow.com/a/11970006/796832
  * @see https://drive.google.com/viewerng/viewer?a=v&pid=sites&srcid=ZGVmYXVsdGRvbWFpbnxqa2dhZGdldHN0b3JlfGd4OjQ4MzI5M2Y0MjNmNzI2MjY
  */
-export function offsetCoords(coords: Coordinate[], offset: number): Coordinate[];
+export function ol_coordinate_offsetCoords(coords: Coordinate[], offset: number): Coordinate[];
 /** Find the segment a point belongs to
  * @param {Coordinate} pt
  * @param {Array<Coordinate>} coords
  * @return {} the index (-1 if not found) and the segment
  */
-export function findSegment(pt: Coordinate, coords: Coordinate[]): any;
+export function ol_coordinate_findSegment(pt: Coordinate, coords: Coordinate[]): any;
 /**
  * Split a Polygon geom with horizontal lines
  * @param {Array<Coordinate>} geom
@@ -45,4 +55,4 @@ export function findSegment(pt: Coordinate, coords: Coordinate[]): any;
  * @param {number} n contour index
  * @return {Array<Array<Coordinate>>}
  */
-export function splitH(geom: Coordinate[], y: number, n: number): Coordinate[][];
+export function ol_coordinate_splitH(geom: Coordinate[], y: number, n: number): Coordinate[][];

--- a/@types/ol-ext/geom/LineStringSplitAt.d.ts
+++ b/@types/ol-ext/geom/LineStringSplitAt.d.ts
@@ -1,0 +1,12 @@
+import { Coordinate } from 'ol/coordinate';
+
+declare module 'ol/geom/LineString' {
+  export default interface LineString {
+    /** Split a lineString by a point or a list of points
+     *	NB: points must be on the line, use getClosestPoint() to get one
+     * @param {ol.Coordinate | Array<ol.Coordinate>} pt points to split the line
+     * @param {Number} tol distance tolerance for 2 points to be equal
+     */
+    splitAt(pt: Coordinate|Coordinate[], tol: number): LineString[];
+  }
+}

--- a/@types/ol-ext/geom/Scribble.d.ts
+++ b/@types/ol-ext/geom/Scribble.d.ts
@@ -1,0 +1,34 @@
+import MultiLineString from 'ol/geom/MultiLineString';
+
+export interface Options {
+  /** interval beetween lines */
+  interval: number;
+  /** hatch angle in radian, default PI/2 */
+  angule: number;
+}
+
+declare module 'ol/geom/MultiPolygon' {
+  export default interface MultiPolygon {
+    /**
+     * Calculate a MultiPolyline to fill a Polygon with a scribble effect that appears hand-made
+     * @param {} options
+     * @param {Number} options.interval interval beetween lines
+     * @param {Number} options.angle hatch angle in radian, default PI/2
+     * @return {ol_geom_MultiLineString|null} the resulting MultiLineString geometry or null if none
+     */
+    scribbleFill(options: Options): MultiLineString|null;
+  }
+}
+
+declare module 'ol/geom/Polygon' {
+  export default interface Polygon {
+    /**
+     * Calculate a MultiPolyline to fill a Polygon with a scribble effect that appears hand-made
+     * @param {} options
+     * @param {Number} options.interval interval beetween lines
+     * @param {Number} options.angle hatch angle in radian, default PI/2
+     * @return {ol_geom_MultiLineString|null} the resulting MultiLineString geometry or null if none
+     */
+    scribbleFill(options: Options): MultiLineString|null;
+  }
+}

--- a/@types/ol-ext/geom/sphere.d.ts
+++ b/@types/ol-ext/geom/sphere.d.ts
@@ -1,0 +1,44 @@
+import { Coordinate } from 'ol/coordinate';
+
+/** Compute great circle bearing of two points.
+ * @See http://www.movable-type.co.uk/scripts/latlong.html for the original code
+ * @param {ol.coordinate} origin origin in lonlat
+ * @param {ol.coordinate} destination destination in lonlat
+ * @return {number} bearing angle in radian
+ */
+export function greatCircleBearing(origin: Coordinate, destination: Coordinate): number;
+
+export interface ComputeDestinationPointOptions {
+  /** normalize longitude beetween -180/180, deafulet true */
+  normalize?: boolean;
+  /** sphere radius, default 6371008.8 */
+  radius?: number;
+}
+
+/** 
+ * Computes the destination point given an initial point, a distance and a bearing
+ * @See http://www.movable-type.co.uk/scripts/latlong.html for the original code
+ * @param {ol.coordinate} origin stating point in lonlat coords
+ * @param {number} distance
+ * @param {number} bearing bearing angle in radian
+ * @param {*} options
+ *  @param {boolean} normalize normalize longitude beetween -180/180, deafulet true
+ *  @param {number|undefined} options.radius sphere radius, default 6371008.8
+ */
+export function computeDestinationPoint(origin: Coordinate, distance: number, bearing: number, options?: ComputeDestinationPointOptions): [number, number];
+
+export interface GreatCircleTrackOptions {
+  /** distance between point along the track in meter, default 1km (1000) */
+  distance?: number;
+  /** sphere radius, default 6371008.8 */
+  radius?: number;
+}
+
+/** Calculate a track along the great circle given an origin and a destination
+ * @param {ol.coordinate} origin origin in lonlat
+ * @param {ol.coordinate} destination destination in lonlat
+ * @param {number} distance distance between point along the track in meter, default 1km (1000)
+ * @param {number|undefined} radius sphere radius, default 6371008.8
+ * @return {Array<ol.coordinate>}
+ */
+export function greatCircleTrack(origin: Coordinate, destination: Coordinate, options?: GreatCircleTrackOptions): Coordinate[];

--- a/@types/ol-ext/geom/validDFCICoord.d.ts
+++ b/@types/ol-ext/geom/validDFCICoord.d.ts
@@ -1,8 +1,0 @@
-import { Coordinate } from 'ol/coordinate';
-import Projection from 'ol/proj/Projection';
-/** Coordinate is valid for DFCI
- * @param {Coordinate} coord
- * @param {Projection} projection result projection, default EPSG:27572
- * @return {boolean}
- */
-export function validDFCICoord(coord: Coordinate, projection: Projection): boolean;

--- a/@types/ol-ext/interaction/CenterTouch.d.ts
+++ b/@types/ol-ext/interaction/CenterTouch.d.ts
@@ -22,7 +22,7 @@ import { Interaction } from 'ol/interaction';
  *  - targetStyle {Style|Array<Style>} a style to draw the target point, default cross style
  *  - composite {string} composite operation : difference|multiply|xor|screen|overlay|darken|lighter|lighten|...
  */
-export class CenterTouch extends Interaction {
+export default class CenterTouch extends Interaction {
     constructor(options: Options);
     /**
      * Remove the interaction from its current map, if any,  and attach it to a new

--- a/@types/ol-ext/interaction/Clip.d.ts
+++ b/@types/ol-ext/interaction/Clip.d.ts
@@ -14,7 +14,7 @@ export interface Options {
  *  @param {number} options.radius radius of the clip, default 100
  *	@param {layer|Array<layer>} options.layers layers to clip
  */
-export class Clip extends Pointer {
+export default class Clip extends Pointer {
     constructor(options: Options);
     /** Set the map > start postcompose
      */

--- a/@types/ol-ext/interaction/CopyPaste..d.ts
+++ b/@types/ol-ext/interaction/CopyPaste..d.ts
@@ -21,7 +21,7 @@ export interface Options {
  *  @param {VectorSource | Array<VectorSource>} options.sources the source to copy from (used for cut), if not defined, it will use the destination
  *  @param {VectorSource} options.destination the source to copy to
  */
-export class CopyPaste extends Interaction {
+export default class CopyPaste extends Interaction {
     constructor(options: Options);
     /** Sources to cut feature from
      * @param { VectorSource | Array<VectorSource> } sources

--- a/@types/ol-ext/interaction/Delete.d.ts
+++ b/@types/ol-ext/interaction/Delete.d.ts
@@ -8,7 +8,7 @@ import { Interaction } from 'ol/interaction';
  * @fires deleteend
  * @param {*} options interaction.Select options
  */
-export class Delete extends Interaction {
+export default class Delete extends Interaction {
     constructor(options: any);
     /** Get vector source of the map
      * @return {Array<VectorSource}

--- a/@types/ol-ext/interaction/DragOverlay.d.ts
+++ b/@types/ol-ext/interaction/DragOverlay.d.ts
@@ -9,7 +9,7 @@ import { Pointer } from 'ol/interaction';
  * @param {any} options
  *  @param {Overlay|Array<Overlay} options.overlays the overlays to drag
  */
-export class DragOverlay extends Pointer {
+export default class DragOverlay extends Pointer {
     constructor(options: any);
     /** Add an overlay to the interacton
      * @param {Overlay} ov

--- a/@types/ol-ext/interaction/DrawHole.d.ts
+++ b/@types/ol-ext/interaction/DrawHole.d.ts
@@ -20,7 +20,7 @@ export interface Options {
  * 	@param {Array<layer.Vector> | function | undefined} options.layers A list of layers from which polygons should be selected. Alternatively, a filter function can be provided. default: all visible layers
  * 	@param { Style | Array<Style> | StyleFunction | undefined }	Style for the selected features, default: default edit style
  */
-export class DrawHole extends Interaction {
+export default class DrawHole extends Interaction {
     constructor(options: Options, Style: StyleLike);
     /**
      * Remove the interaction from its current map, if any,  and attach it to a new

--- a/@types/ol-ext/interaction/DrawRegular.d.ts
+++ b/@types/ol-ext/interaction/DrawRegular.d.ts
@@ -34,7 +34,7 @@ export interface Options {
  *  @param { number } clickTolerance click tolerance on touch devices, default: 6
  *  @param { number } maxCircleCoordinates Maximum number of point on a circle, default: 100
  */
-export class DrawRegular extends Interaction {
+export default class DrawRegular extends Interaction {
     constructor(options: Options);
     /**
      * Remove the interaction from its current map, if any,  and attach it to a new

--- a/@types/ol-ext/interaction/DrawTouch.d.ts
+++ b/@types/ol-ext/interaction/DrawTouch.d.ts
@@ -3,7 +3,7 @@ import { Coordinate } from 'ol/coordinate';
 import { Vector as VectorSource } from 'ol/source';
 import { Style } from 'ol/style';
 import GeometryType from 'ol/geom/GeometryType';
-import { CenterTouch } from './CenterTouch';
+import CenterTouch from './CenterTouch';
 
 export interface Options {
     source: VectorSource | undefined;
@@ -23,7 +23,7 @@ export interface Options {
  *  - targetStyle {Style|Array<Style>} a style to draw the target point, default cross style
  *  - composite {string} composite operation : difference|multiply|xor|screen|overlay|darken|lighter|lighten|...
  */
-export class DrawTouch extends CenterTouch {
+export default class DrawTouch extends CenterTouch {
     constructor(options: Options);
     /**
      * Remove the interaction from its current map, if any,  and attach it to a new

--- a/@types/ol-ext/interaction/DropFile.d.ts
+++ b/@types/ol-ext/interaction/DropFile.d.ts
@@ -18,7 +18,7 @@ export interface Options {
  *		- formatConstructors {Array<function(new:format.Feature)>|undefined} Format constructors, default [ format.GPX, format.GeoJSON, format.IGC, format.KML, format.TopoJSON ]
  *		- accept {Array<string>|undefined} list of eccepted format, default ["gpx","json","geojson","igc","kml","topojson"]
  */
-export class DropFile extends DragAndDrop {
+export default class DropFile extends DragAndDrop {
     constructor(options: Options);
     /** Set the map
      */

--- a/@types/ol-ext/interaction/FillAttribute.d.ts
+++ b/@types/ol-ext/interaction/FillAttribute.d.ts
@@ -15,7 +15,7 @@ export interface Options {
  *  @param {boolean} options.cursor use a paint bucket cursor, default true
  * @param {*} properties The properties as key/value
  */
-export class FillAttribute extends Interaction {
+export default class FillAttribute extends Interaction {
     constructor(options: Options, properties: any);
     /** Activate the interaction
      * @param {boolean} active

--- a/@types/ol-ext/interaction/Flashlight.d.ts
+++ b/@types/ol-ext/interaction/Flashlight.d.ts
@@ -16,7 +16,7 @@ export interface Options {
  *		- fill {Color} fill color, default rgba(0,0,0,0.8)
  *		- radius {number} radius of the flash
  */
-export class Flashlight extends Pointer {
+export default class Flashlight extends Pointer {
     constructor(options: Options);
     /** Set the map > start postcompose
      */

--- a/@types/ol-ext/interaction/FocusMap.d.ts
+++ b/@types/ol-ext/interaction/FocusMap.d.ts
@@ -4,7 +4,7 @@ import { Interaction } from 'ol/interaction';
  * @fires focus
  * @extends {Interaction}
  */
-export class FocusMap extends Interaction {
+export default class FocusMap extends Interaction {
     /** Set the map > add the focus button and focus on the map when pointerdown to enable keyboard events.
      */
     setMap(): void;

--- a/@types/ol-ext/interaction/GeolocationDraw.d.ts
+++ b/@types/ol-ext/interaction/GeolocationDraw.d.ts
@@ -32,7 +32,7 @@ export interface Options {
  *	@param {boolean|auto|position|visible} options.followTrack true if you want the interaction to follow the track on the map, default true
  *	@param { Style | Array.<Style> | StyleFunction | undefined } options.style Style for sketch features.
  */
-export class GeolocationDraw extends Interaction {
+export default class GeolocationDraw extends Interaction {
     constructor(options: Options);
     /**
      * Remove the interaction from its current map, if any,  and attach it to a new

--- a/@types/ol-ext/interaction/Hover.d.ts
+++ b/@types/ol-ext/interaction/Hover.d.ts
@@ -19,7 +19,7 @@ export interface Options {
  *	@param {number | undefined} options.hitTolerance Hit-detection tolerance in pixels.
  *	@param { function | undefined } options.handleEvent Method called by the map to notify the interaction that a browser event was dispatched to the map. The function may return false to prevent the propagation of the event to other interactions in the map's interactions chain.
  */
-export class Hover extends Interaction {
+export default class Hover extends Interaction {
     constructor(options: Options, optionsfeatureFilter: ((...params: any[]) => any) | undefined);
     /**
      * Remove the interaction from its current map, if any,  and attach it to a new

--- a/@types/ol-ext/interaction/LongTouch.d.ts
+++ b/@types/ol-ext/interaction/LongTouch.d.ts
@@ -11,6 +11,6 @@ export interface Options {
  * 	@param {function | undefined} options.handleLongTouchEvent Function handling "longtouch" events, it will receive a mapBrowserEvent.
  *	@param {interger | undefined} options.delay The delay for a long touch in ms, default is 1000
  */
-export class LongTouch extends Interaction {
+export default class LongTouch extends Interaction {
     constructor(options: Options);
 }

--- a/@types/ol-ext/interaction/ModifyFeature.d.ts
+++ b/@types/ol-ext/interaction/ModifyFeature.d.ts
@@ -38,7 +38,7 @@ export interface Options {
  *  @param {EventsConditionType | undefined} options.deleteCondition A function that takes an MapBrowserEvent and returns a boolean to indicate whether that event should be handled. By default, events.condition.singleClick with events.condition.altKeyOnly results in a vertex deletion.
  *  @param {EventsConditionType | undefined} options.insertVertexCondition A function that takes an MapBrowserEvent and returns a boolean to indicate whether a new vertex can be added to the sketch features. Default is events.condition.always
  */
-export class ModifyFeature extends Pointer {
+export default class ModifyFeature extends Pointer {
     constructor(options: Options);
     /**
      * Remove the interaction from its current map, if any,  and attach it to a new

--- a/@types/ol-ext/interaction/ModifyTouch.d.ts
+++ b/@types/ol-ext/interaction/ModifyTouch.d.ts
@@ -15,7 +15,7 @@ export interface Options {
  *  @param {String|undefined} options.title title to display, default "remove point"
  *  @param {Boolean|undefined} options.usePopup use a popup, default true
  */
-export class ModifyTouch extends Modify {
+export default class ModifyTouch extends Modify {
     constructor(options: Options);
     /**
      * Remove the interaction from its current map, if any,  and attach it to a new

--- a/@types/ol-ext/interaction/Offset.d.ts
+++ b/@types/ol-ext/interaction/Offset.d.ts
@@ -23,7 +23,7 @@ export interface Options {
  *	@param {VectorSource | undefined} options.source source to duplicate feature when ctrl key is down
  *	@param {boolean} options.duplicate force feature to duplicate (source must be set)
  */
-export class Offset extends Pointer {
+export default class Offset extends Pointer {
     constructor(options: Options);
     /**
      * Remove the interaction from its current map, if any,  and attach it to a new

--- a/@types/ol-ext/interaction/Ripple.d.ts
+++ b/@types/ol-ext/interaction/Ripple.d.ts
@@ -14,7 +14,7 @@ export interface Options {
      *		- fill {Color} fill color, default rgba(0,0,0,0.8)
      *		- radius {number} radius of the flash
      */
-export class Ripple extends Pointer {
+export default class Ripple extends Pointer {
     constructor(options: Options);
     /** Set the map > start postcompose
      */

--- a/@types/ol-ext/interaction/SelectCluster.d.ts
+++ b/@types/ol-ext/interaction/SelectCluster.d.ts
@@ -36,7 +36,7 @@ export interface Options {
  * @fires interaction.SelectEvent
  * @api stable
  */
-export class SelectCluster extends Select {
+export default class SelectCluster extends Select {
     constructor(options?: Options);
     /**
      * Remove the interaction from its current map, if any,  and attach it to a new

--- a/@types/ol-ext/interaction/SnapGuides.d.ts
+++ b/@types/ol-ext/interaction/SnapGuides.d.ts
@@ -18,7 +18,7 @@ export interface Options {
  *  - enableInitialGuides {bool | undefined} whether to draw initial guidelines based on the maps orientation, default false.
  *	- style {Style | Array<Style> | undefined} Style for the sektch features.
  */
-export class SnapGuides extends Interaction {
+export default class SnapGuides extends Interaction {
     constructor(options: Options);
     /**
      * Remove the interaction from its current map, if any,  and attach it to a new

--- a/@types/ol-ext/interaction/Split.d.ts
+++ b/@types/ol-ext/interaction/Split.d.ts
@@ -27,7 +27,7 @@ export interface Options {
  *  @param {Style | Array<Style> | undefined} options.sketchStyle Style for the sektch features.
  *  @param {function|undefined} options.tolerance Distance between the calculated intersection and a vertex on the source geometry below which the existing vertex will be used for the split.  Default is 1e-10.
  */
-export class Split extends Interaction {
+export default class Split extends Interaction {
     constructor(options: Options);
     /**
      * Remove the interaction from its current map, if any,  and attach it to a new

--- a/@types/ol-ext/interaction/Splitter.d.ts
+++ b/@types/ol-ext/interaction/Splitter.d.ts
@@ -24,7 +24,7 @@ export interface Options {
  *	- tolerance {function|undefined} Distance between the calculated intersection and a vertex on the source geometry below which the existing vertex will be used for the split. Default is 1e-10.
  * @todo verify auto intersection on features that split.
  */
-export class Splitter extends Interaction {
+export default class Splitter extends Interaction {
     constructor(options: Options);
     /** Calculate intersection on 2 segs
     * @param {Array<Coordinate>} s1 first seg to intersect (2 points)

--- a/@types/ol-ext/interaction/Synchronize.d.ts
+++ b/@types/ol-ext/interaction/Synchronize.d.ts
@@ -11,7 +11,7 @@ export interface Options {
  * @param {olx.interaction.SynchronizeOptions}
  *  - maps {Array<Map>} An array of maps to synchronize with the map of the interaction
  */
-export class Synchronize extends Interaction {
+export default class Synchronize extends Interaction {
     constructor(options: Options);
     /**
      * Remove the interaction from its current map, if any,  and attach it to a new

--- a/@types/ol-ext/interaction/TinkerBell.d.ts
+++ b/@types/ol-ext/interaction/TinkerBell.d.ts
@@ -10,7 +10,7 @@ export interface Options {
  *	@param {interaction.TinkerBell.options}  options flashlight param
  *		- color {color} color of the sparkles
  */
-export class TinkerBell extends Pointer {
+export default class TinkerBell extends Pointer {
     constructor(options: Options);
     /** Set the map > start postcompose
      */

--- a/@types/ol-ext/interaction/TouchCompass.d.ts
+++ b/@types/ol-ext/interaction/TouchCompass.d.ts
@@ -14,7 +14,7 @@ export interface Options {
  *	- Size {Number} Size of the compass in px, default 80
  *	- alpha {Number} opacity of the compass, default 0.5
  */
-export class TouchCompass extends Pointer {
+export default class TouchCompass extends Pointer {
     constructor(options: Options);
     /** Compass Image as a JS Image object
     * @api

--- a/@types/ol-ext/interaction/Transform.d.ts
+++ b/@types/ol-ext/interaction/Transform.d.ts
@@ -46,7 +46,7 @@ export interface Options {
  *	@param {} options.style list of style for handles
  *
  */
-export class Transform extends Pointer {
+export default class Transform extends Pointer {
     constructor(options: Options);
     /** Cursors for transform
      */

--- a/@types/ol-ext/interaction/UndoRedo.d.ts
+++ b/@types/ol-ext/interaction/UndoRedo.d.ts
@@ -7,7 +7,7 @@ import { Interaction } from 'ol/interaction';
  * @fires redo
  * @param {*} options
  */
-export class UndoRedo extends Interaction {
+export default class UndoRedo extends Interaction {
     constructor(options: any);
     /** Add a custom undo/redo
      * @param {string} action the action key name

--- a/@types/ol-ext/layer/Geoportail.d.ts
+++ b/@types/ol-ext/layer/Geoportail.d.ts
@@ -28,7 +28,7 @@ export interface Options {
  *  @param {string} options.crossOrigin default 'anonymous'
  *  @param {string} options.wrapX default true
  */
-export class Geoportail extends WMTS {
+export default class Geoportail extends WMTS {
     constructor(layer?: string, options?: Options);
     /** Standard IGN-GEOPORTAIL attribution
      */

--- a/@types/ol-ext/layer/render3D.d.ts
+++ b/@types/ol-ext/layer/render3D.d.ts
@@ -11,7 +11,7 @@ import { Style } from 'ol/style';
  *  @param {number} param.defaultHeight default height if none is return by a propertie
  *  @param {function|string|Number} param.height a height function (returns height giving a feature) or a popertie name for the height or a fixed value
  */
-export class render3D {
+export default class render3D {
     constructor(param: {
         layer: Vector;
         maxResolution: number;

--- a/@types/ol-ext/overlay/Magnify.d.ts
+++ b/@types/ol-ext/overlay/Magnify.d.ts
@@ -1,5 +1,6 @@
 import { Map as _ol_Map_, Overlay } from 'ol';
 import { Options as OverlayOptions } from 'ol/Overlay';
+
 /**
  * @classdesc
  *	The Magnify overlay add a "magnifying glass" effect to an OL3 map that displays
@@ -10,7 +11,7 @@ import { Options as OverlayOptions } from 'ol/Overlay';
  * @param {olx.OverlayOptions} options Overlay options
  * @api stable
  */
-export class Magnify extends Overlay {
+export default class Magnify extends Overlay {
     constructor(options?: OverlayOptions);
     /**
      * Set the map instance the overlay is associated with.

--- a/@types/ol-ext/overlay/Placemark.d.ts
+++ b/@types/ol-ext/overlay/Placemark.d.ts
@@ -33,7 +33,7 @@ popup.hide();
 *	@param {function|undefined} options.onshow callback function when popup is shown
 * @api stable
  */
-export class Placemark extends Overlay {
+export default class Placemark extends Overlay {
     constructor(options: Options);
     /**
      * Set the position and the content of the placemark (hide it before to enable animation).

--- a/@types/ol-ext/overlay/Popup.d.ts
+++ b/@types/ol-ext/overlay/Popup.d.ts
@@ -3,9 +3,6 @@ import { Coordinate } from 'ol/coordinate';
 import Feature from 'ol/Feature';
 import OverlayPositioning from 'ol/OverlayPositioning';
 
-
-
-
 /** Template attributes for popup
  * @typedef {Object} TemplateAttributes
  * @property {string} title
@@ -72,7 +69,7 @@ popup.hide();
 *		the 'auto' positioning var the popup choose its positioning to stay on the map.
 * @api stable
  */
-export class Popup extends Overlay {
+export default class Popup extends Overlay {
     constructor(options: Options);
     /**
      * Set a close box to the popup.

--- a/@types/ol-ext/overlay/PopupFeature.d.ts
+++ b/@types/ol-ext/overlay/PopupFeature.d.ts
@@ -1,7 +1,7 @@
 import { Coordinate } from 'ol/coordinate';
 import Feature from 'ol/Feature';
 import OverlayPositioning from 'ol/OverlayPositioning';
-import { Popup, Template } from './Popup';
+import { default as Popup, Template } from './Popup';
 
 export interface Options {
     popupClass: string;
@@ -34,7 +34,7 @@ export interface Options {
  *  @param {boolean} options.maxChar max char to display in a cell, default 200
  *  @api stable
  */
-export class PopupFeature extends Popup {
+export default class PopupFeature extends Popup {
     constructor(options: Options);
     /** Set the template
      * @param {Template} template A template with a list of properties to use in the popup

--- a/@types/ol-ext/overlay/Tooltip.d.ts
+++ b/@types/ol-ext/overlay/Tooltip.d.ts
@@ -3,7 +3,7 @@ import { Coordinate } from 'ol/coordinate';
 import Feature from 'ol/Feature';
 import Event from 'ol/events/Event';
 import OverlayPositioning from 'ol/OverlayPositioning';
-import { Popup } from './Popup';
+import { default as Popup } from './Popup';
 
 export interface Options {
     popupClass: string;
@@ -28,7 +28,7 @@ export interface Options {
  *		the 'auto' positioning var the popup choose its positioning to stay on the map.
  * @api stable
  */
-export class Tooltip extends Popup {
+export default class Tooltip extends Popup {
     constructor(options: Options);
     /**
      * Set the map instance the control is associated with

--- a/@types/ol-ext/render/HexGrid.d.ts
+++ b/@types/ol-ext/render/HexGrid.d.ts
@@ -21,7 +21,7 @@ export declare type HexagonLayout = 'pointy' | 'flat';
 *	@param {Coordinate} [options.origin] orgin of the grid, default [0,0]
 *	@param {HexagonLayout} [options.layout] grid layout, default pointy
  */
-export class HexGrid extends Object {
+export default class HexGrid extends Object {
     constructor(options?: Options);
     /** Layout
      */
@@ -111,12 +111,12 @@ export class HexGrid extends Object {
     * @param {hex} hex
     * @return {Coordinate}
      */
-    hex2coord(hex: hex): Coordinate;
+    hex2coord(hex: Array<Coordinate>): Coordinate;
     /** Convert coord to hex
     * @param {Coordinate} coord
     * @return {hex}
      */
-    coord2hex(coord: Coordinate): hex;
+    coord2hex(coord: Coordinate): Array<Coordinate>;
     /** Calculate distance between to hexagon (number of cube)
     * @param {Coordinate} a first cube coord
     * @param {Coordinate} a second cube coord

--- a/@types/ol-ext/render/InseeGrid.d.ts
+++ b/@types/ol-ext/render/InseeGrid.d.ts
@@ -15,7 +15,7 @@ export interface Options {
  * @param {Object} [options]
  *  @param {number} [options.Size] Size grid Size in meter, default 200 (200x200m)
  */
-export class InseeGrid extends Object {
+export default class InseeGrid extends Object {
     constructor(options?: Options);
     /** Grid Extent (in EPSG:3035)
      */

--- a/@types/ol-ext/render/Ordering.d.ts
+++ b/@types/ol-ext/render/Ordering.d.ts
@@ -1,20 +1,33 @@
-/** Ordering function for layer.Vector renderOrder parameter
-*	ordering.fn (options)
-*	It will return an ordering function (f0,f1)
-*	@namespace
- */
-    /** y-Ordering
-    *	@return ordering function (f0,f1)
-     */
-   export function yOrdering(): any;
-    /** Order with a feature attribute
-     * @param options
-     *  @param {string} options.attribute ordering attribute, default zIndex
-     *  @param {function} options.equalFn ordering function for equal values
-     * @return ordering function (f0,f1)
-     */
-   export  function zIndex(options: {
-        attribute: string;
-        equalFn: (...params: any[]) => any;
-    }): any;
+import { Geometry } from 'ol/geom';
 
+/** y-Ordering
+*	@return ordering function (f0,f1)
+  */
+declare function yOrdering(): (f0: Geometry, f1: Geometry) => number;
+
+export interface ZIndexOptions {
+  /** ordering attribute, default zIndex */
+  attribute?: string;
+  /** ordering function for equal values */
+  equalFn?: (f0: Geometry, f1: Geometry) => number;
+}
+
+/** Order with a feature attribute
+ * @param options
+ *  @param {string} options.attribute ordering attribute, default zIndex
+ *  @param {function} options.equalFn ordering function for equal values
+ * @return ordering function (f0,f1)
+ */
+declare function zIndex(options: {
+    attribute: string;
+    equalFn: (...params: any[]) => any;
+}): any;
+
+interface Ordering {
+  yOrdering: typeof yOrdering;
+  zIndex: typeof zIndex;
+}
+
+declare const ordering: Ordering;
+
+export default ordering;

--- a/@types/ol-ext/source/BinBase.d.ts
+++ b/@types/ol-ext/source/BinBase.d.ts
@@ -16,7 +16,7 @@ export interface Options {
  *  @param {(f: Feature) => Point} [options.geometryFunction] Function that takes an Feature as argument and returns an Point as feature's center.
  *  @param {(bin: Feature, features: Array<Feature>)} [options.flatAttributes] Function takes a bin and the features it contains and aggragate the features in the bin attributes when saving
  */
-export class BinBase extends VectorSource {
+export default class BinBase extends VectorSource {
     constructor(options: Options);
     /**
      * Get the bin that contains a feature

--- a/@types/ol-ext/source/DBPedia.d.ts
+++ b/@types/ol-ext/source/DBPedia.d.ts
@@ -18,7 +18,7 @@ export interface Options {
 * @extends {VectorSource}
 * @param {olx.source.DBPedia=} opt_options
  */
-export class DBPedia extends VectorSource {
+export default class DBPedia extends VectorSource {
     constructor(opt_options?: Options);
     /** Decode RDF attributes and choose to add feature to the layer
     * @param {feature} the feature

--- a/@types/ol-ext/source/DFCI.d.ts
+++ b/@types/ol-ext/source/DFCI.d.ts
@@ -6,7 +6,7 @@ import { Vector as VectorSource } from 'ol/source';
  * @param {any} options Vector source options
  *  @param {Array<Number>} resolutions a list of resolution to change the drawing level, default [1000,100,20]
  */
-export class DFCI extends VectorSource {
+export default class DFCI extends VectorSource {
     constructor(options: any, resolutions: Number[]);
     /** Cacluate grid according Extent/resolution
      */

--- a/@types/ol-ext/source/Delaunay.d.ts
+++ b/@types/ol-ext/source/Delaunay.d.ts
@@ -1,9 +1,0 @@
-import { Vector as VectorSource } from 'ol/source';
-/** Delaunay source
- * Calculate a delaunay triangulation from points in a source
- * @param {*} options extend Vector options
- *  @param {Vector} options.source the source that contains the points
- */
-export function Delaunay(options: {
-    source: VectorSource;
-}): void;

--- a/@types/ol-ext/source/FeatureBin.d.ts
+++ b/@types/ol-ext/source/FeatureBin.d.ts
@@ -16,7 +16,7 @@ export interface Options {
  *  @param {(f: Feature) => Point} [options.geometryFunction] Function that takes an Feature as argument and returns an Point as feature's center.
  *  @param {(bin: Feature, features: Array<Feature>)} [options.flatAttributes] Function takes a bin and the features it contains and aggragate the features in the bin attributes when saving
  */
-export class FeatureBin extends VectorSource {
+export default class FeatureBin extends VectorSource {
     constructor(options: Options);
     /** Set grid Size
      * @param {Feature} features

--- a/@types/ol-ext/source/GeoImage.d.ts
+++ b/@types/ol-ext/source/GeoImage.d.ts
@@ -8,7 +8,7 @@ import { ImageCanvas } from 'ol/source';
 * @extends {source.ImageCanvas}
 * @param {olx.source.GeoImageOptions=} options
  */
-export class GeoImage extends ImageCanvas {
+export default class GeoImage extends ImageCanvas {
     constructor(options?: {});
     /**
      * Get coordinate of the image center.

--- a/@types/ol-ext/source/GridBin.d.ts
+++ b/@types/ol-ext/source/GridBin.d.ts
@@ -16,7 +16,7 @@ export interface Options {
  *  @param {(f: Feature) => Point} [options.geometryFunction] Function that takes an Feature as argument and returns an Point as feature's center.
  *  @param {(bin: Feature, features: Array<Feature>)} [options.flatAttributes] Function takes a bin and the features it contains and aggragate the features in the bin attributes when saving
  */
-export class GridBin extends VectorSource {
+export default class GridBin extends VectorSource {
     constructor(options: Options);
     /** Set grid projection
      * @param {ProjectionLike} proj

--- a/@types/ol-ext/source/HexBin.d.ts
+++ b/@types/ol-ext/source/HexBin.d.ts
@@ -2,7 +2,7 @@ import { Coordinate } from 'ol/coordinate';
 import Feature from 'ol/Feature';
 import { Polygon } from 'ol/geom';
 import { Vector as VectorSource } from 'ol/source';
-import { HexGrid } from 'render/HexGrid';
+import HexGrid from '../render/HexGrid';
 
 export interface Options {
     source: VectorSource;
@@ -20,7 +20,7 @@ export interface Options {
  *  @param {(f: Feature) => Point} [options.geometryFunction] Function that takes an Feature as argument and returns an Point as feature's center.
  *  @param {(bin: Feature, features: Array<Feature>)} [options.flatAttributes] Function takes a bin and the features it contains and aggragate the features in the bin attributes when saving
  */
-export class HexBin extends VectorSource {
+export default class HexBin extends VectorSource {
     constructor(options: Options);
     /** The HexGrid
      * 	@type {HexGrid}

--- a/@types/ol-ext/source/InseeBin.d.ts
+++ b/@types/ol-ext/source/InseeBin.d.ts
@@ -17,7 +17,7 @@ export interface Options {
  *  @param {(f: Feature) => Point} [options.geometryFunction] Function that takes an Feature as argument and returns an Point as feature's center.
  *  @param {(bin: Feature, features: Array<Feature>)} [options.flatAttributes] Function takes a bin and the features it contains and aggragate the features in the bin attributes when saving
  */
-export class InseeBin extends VectorSource {
+export default class InseeBin extends VectorSource {
     constructor(options: Options);
     /** Set grid Size
      * @param {number} Size

--- a/@types/ol-ext/source/Mapillary.d.ts
+++ b/@types/ol-ext/source/Mapillary.d.ts
@@ -7,7 +7,7 @@ import { Options as VectorSourceOptions } from 'ol/source/Vector';
 * @extends {VectorSource}
 * @param {olx.source.Mapillary=} options
  */
-export class Mapillary extends VectorSource {
+export default class Mapillary extends VectorSource {
     constructor(options?: VectorSourceOptions);
     /** Max resolution to load features
      */

--- a/@types/ol-ext/source/Overpass.d.ts
+++ b/@types/ol-ext/source/Overpass.d.ts
@@ -1,4 +1,4 @@
-import { default as Attribution } from 'ol/control/Attribution';
+import Attribution from 'ol/control/Attribution';
 import { Vector as VectorSource } from 'ol/source';
 import { LoadingStrategy } from 'ol/source/Vector';
 
@@ -26,7 +26,7 @@ export interface Options {
  *  @param {string|Attribution|Array<string>} options.attributions source attribution, default OSM attribution
  *  @param {LoadingStrategy} options.strategy loading strategy, default loadingstrategy.bbox
  */
-export class Overpass extends VectorSource {
+export default class Overpass extends VectorSource {
     constructor(options: Options);
     /** Ovepass API Url
      */

--- a/@types/ol-ext/source/WikiCommons.d.ts
+++ b/@types/ol-ext/source/WikiCommons.d.ts
@@ -7,7 +7,7 @@ import { Options as VectorSourceOptions } from 'ol/source/Vector';
 * @extends {VectorSource}
 * @param {olx.source.WikiCommons=} options
  */
-export class WikiCommons extends VectorSource {
+export default class WikiCommons extends VectorSource {
     constructor(options?: VectorSourceOptions);
     /** Max resolution to load features
      */

--- a/@types/ol-ext/style/Chart.d.ts
+++ b/@types/ol-ext/style/Chart.d.ts
@@ -34,7 +34,7 @@ export interface Options {
  * @implements {structs.IHasChecksum}
  * @api
  */
-export class Chart extends RegularShape {
+export default class Chart extends RegularShape {
     constructor(options: Options);
     /** Default color set: classic, dark, pale, pastel, neon
      */

--- a/@types/ol-ext/style/FillPattern.d.ts
+++ b/@types/ol-ext/style/FillPattern.d.ts
@@ -45,7 +45,7 @@ export interface Options {
  * @implements {structs.IHasChecksum}
  * @api
  */
-export class FillPattern extends Fill {
+export default class FillPattern extends Fill {
     constructor(options?: Options);
     /**
      * Clones the style.

--- a/@types/ol-ext/style/FlowLine.d.ts
+++ b/@types/ol-ext/style/FlowLine.d.ts
@@ -21,7 +21,7 @@ export interface Options {
  *  @param {colorLike|function} options.color Stroke color or a function that gets a feature and the position (beetween [0,1]) and returns current color
  *  @param {colorLike} options.color2 Final sroke color
  */
-export class FlowLine extends Style {
+export default class FlowLine extends Style {
     constructor(options: Options);
     /** Set the initial width
      * @param {number} width width, default 0

--- a/@types/ol-ext/style/FontSymbol.d.ts
+++ b/@types/ol-ext/style/FontSymbol.d.ts
@@ -37,7 +37,7 @@ export interface Options {
  * @implements {structs.IHasChecksum}
  * @api
  */
-export class FontSymbol extends RegularShape {
+export default class FontSymbol extends RegularShape {
     constructor(options: Options);
     /**
      *	Font defs

--- a/@types/ol-ext/style/Photo.d.ts
+++ b/@types/ol-ext/style/Photo.d.ts
@@ -32,7 +32,7 @@ export interface Options {
  * @implements {structs.IHasChecksum}
  * @api
  */
-export class Photo extends RegularShape {
+export default class Photo extends RegularShape {
     constructor(options: Options);
     /**
      * Clones the style.

--- a/@types/ol-ext/style/SetTextPath.d.ts
+++ b/@types/ol-ext/style/SetTextPath.d.ts
@@ -5,6 +5,6 @@
 *	@param {visible|ellipsis|string} textOverflow
 *	@param {number} minWidth minimum width (px) to draw text, default 0
  */
-export class TextPath {
+export default class TextPath {
     constructor(options: any, textOverflow: 'visible' | 'ellipsis' | string, minWidth: number);
 }

--- a/@types/ol-ext/style/Shadow.d.ts
+++ b/@types/ol-ext/style/Shadow.d.ts
@@ -22,7 +22,7 @@ export interface Options {
  * @implements {structs.IHasChecksum}
  * @api
  */
-export class Shadow extends RegularShape {
+export default class Shadow extends RegularShape {
     constructor(options: Options);
     /**
      * Clones the style.

--- a/@types/ol-ext/style/StrokePattern.d.ts
+++ b/@types/ol-ext/style/StrokePattern.d.ts
@@ -1,4 +1,4 @@
-import { FillPattern } from './FillPattern';
+import FillPattern from './FillPattern';
 
 
 export interface FillPatternOptions {
@@ -32,7 +32,7 @@ export interface FillPatternOptions {
  * @implements {structs.IHasChecksum}
  * @api
  */
-export class StrokePattern extends FillPattern {
+export default class StrokePattern extends FillPattern {
     constructor(options: FillPatternOptions);
     /**
      * Clones the style.

--- a/@types/ol-ext/style/style.d.ts
+++ b/@types/ol-ext/style/style.d.ts
@@ -1,6 +1,6 @@
 import { Fill, Stroke, Image } from 'ol/style';
 import { ColorLike } from 'ol/colorlike';
-import { FillPattern } from './FillPattern';
+import FillPattern from './FillPattern';
 /** Vector feature rendering styles.
  * @namespace style
  * @see {@link https://openlayers.org/en/master/apidoc/module-ol_style.html}

--- a/@types/ol-ext/types.d.ts
+++ b/@types/ol-ext/types.d.ts
@@ -2,7 +2,7 @@ import { Map as _ol_Map_, View, Overlay } from 'ol';
 import { Options as OverlayOptions } from 'ol/Overlay';
 
 import Collection from 'ol/Collection';
-import { default as Attribution, default as ol_control_Attribution } from 'ol/control/Attribution';
+import Attribution from 'ol/control/Attribution';
 import ol_control_Control from 'ol/control/Control';
 import ol_control_ScaleLine from 'ol/control/ScaleLine';
 import { Coordinate, CoordinateFormat } from 'ol/coordinate';
@@ -29,6 +29,7 @@ import { Pixel } from 'ol/pixel';
 import FeatureFormat from 'ol/format/Feature';
 import Event from 'ol/events/Event';
 import OverlayPositioning from 'ol/OverlayPositioning';
+import featureAnimation from './featureanimation/FeatureAnimation';
 
 
 /** The map is the core component of OpenLayers.
@@ -114,7 +115,3 @@ type animationControler = {
     stop: (...params: any[]) => any;
     isPlaying: (...params: any[]) => any;
 };
-
-
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,9 +64,9 @@
       "integrity": "sha512-FMdVn84tJJdV+xe+53sYiZS4R5yn1mAIxfj+DVoNiQjTYz1+OYmjwEZr1ev9nU0axXwda0QDbYl06QHanRVH3A=="
     },
     "@types/ol": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@types/ol/-/ol-5.3.5.tgz",
-      "integrity": "sha512-zX9Epdg4YJvi8diEFgn9sgfpHjij7TEz5lswqe2cvNb3GM9qJRjHU9kKUQDZcJH2aKwKqRQgvyn1IWsJk/MiJA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@types/ol/-/ol-6.3.1.tgz",
+      "integrity": "sha512-EfScx11HU/aCha+hU8jo+34BuTDIBIwOHFGjwGYEPfMh7FbYlKLMDcWjn6RM2w4eRnOmQXHqDfL8uObyJs1EmQ==",
       "requires": {
         "@types/arcgis-rest-api": "*",
         "@types/geojson": "*",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@siedlerchr/types-ol-ext",
   "version": "1.0.0",
   "description": "Type definitions for ol-ext",
-  "main": "index.js",
+  "main": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "tsc -p tsconfig.lint.json --pretty && tslint -p tsconfig.lint.json",
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/Siedlerchr/types-ol-ext#readme",
   "dependencies": {
-    "@types/ol": "^5.3.5",
+    "@types/ol": "^6.3.1",
     "dtslint": "^0.8.0",
     "jsdoc": "^3.6.3",
     "ol": "^6.0.1",


### PR DESCRIPTION
Classes in ol-ext library are exported as default, not as named exports