### PR TITLE
Move npm publish folder from 'ol-ext' to 'npm'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ typings/
 .history
 
 /ol-ext
+/npm
 
 # End of https://www.gitignore.io/api/visualstudiocode
 

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -23,7 +23,7 @@
    npm run lint
    ```
 
-2. Prepare package on `./ol-ext` folder
+2. Prepare package on `./npm` folder
 
    ```bash
    npm run prepare-npm
@@ -34,11 +34,11 @@
 1. Check what contents are published by dry-run.
 
    ```bash
-   npm publish ./ol-ext --access=public --dry-run
+   npm publish ./npm --access=public --dry-run
    ```
 
 2. Publish NPM package.
 
    ```bash
-   npm publish ./ol-ext --access=public
+   npm publish ./npm --access=public
    ```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "replace-examples": "node scripts/replaceExampleHtmlJsTags.js",
     "copy-examples": "node scripts/copyExampleBackupJsToTs.js",
     "build-examples": "webpack -c examples/webpack.config.js --progress --color",
-    "prepare-npm": "rm -rf ./ol-ext && cp -r @types/ol-ext ./ol-ext && cp package.json ./ol-ext/ && cp README.md ./ol-ext/ && cp LICENSE ./ol-ext/"
+    "prepare-npm": "rm -rf ./npm && cp -r @types/ol-ext ./npm && cp package.json ./npm/ && cp README.md ./npm/ && cp LICENSE ./npm/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Supports #28.

I confirmed that npm publish works as expected on gtt-project fork repository,
- npm publish result: https://www.npmjs.com/package/@gtt-project/types-ol-ext (1.0.1-1)
- diff: https://github.com/gtt-project/types-ol-ext/compare/feature/move-npm-publish-folder..feature/move-npm-publish-folder-gtt

so, this should be no problem.