### PR TITLE
Check overlay/PopupFeature example

### DIFF
--- a/@types/ol-ext/overlay/Popup.d.ts
+++ b/@types/ol-ext/overlay/Popup.d.ts
@@ -1,36 +1,6 @@
-import { Overlay as ol_Overlay } from 'ol';
+import { Overlay as Overlay } from 'ol';
 import { Coordinate } from 'ol/coordinate';
 import OverlayPositioning from 'ol/OverlayPositioning';
-import Feature from 'ol/Feature';
-
-/** Template attributes for popup
- * @typedef {Object} TemplateAttributes
- * @property {string} title
- * @property {function} format a function that takes an attribute and a feature and returns the formated attribute
- * @property {string} before string to instert before the attribute (prefix)
- * @property {string} after string to instert after the attribute (sudfix)
- * @property {boolean|function} visible boolean or a function (feature, value) that decides the visibility of a attribute entry
- */
-export declare type TemplateAttributes = {
-    title?: string;
-    format?: (val: any, feature: Feature) => any;
-    before?: string;
-    after?: string;
-    visible?: boolean | ((feature: Feature, val: any) => boolean);
-};
-
-/** Template
- * @typedef {Object} Template
- * @property {string|function} title title of the popup, attribute name or a function that takes a feature and returns the title
- * @property {Object.<TemplateAttributes>} attributes a list of template attributes
- */
-export declare type Template = {
-    title?: string | ((feature: Feature) => string);
-    attributes?: {
-        [key: string]: any;
-    };
-};
-
 
 
 /** Openlayers Overlay.
@@ -60,7 +30,7 @@ popup.show(coordinate, "Hello!");
 popup.hide();
 *
 * @constructor
-* @extends {ol_Overlay}
+* @extends {Overlay}
 * @fires show
 * @fires hide
 * @param {} options Extend Overlay options
@@ -74,7 +44,7 @@ popup.hide();
 *		the 'auto' positioning var the popup choose its positioning to stay on the map.
 * @api stable
  */
-export class Popup extends ol_Overlay {
+export default class Popup extends Overlay {
     constructor(options?: Options);
     /**
      * Set a close box to the popup.

--- a/@types/ol-ext/overlay/PopupFeature.d.ts
+++ b/@types/ol-ext/overlay/PopupFeature.d.ts
@@ -1,7 +1,37 @@
 import { Coordinate } from 'ol/coordinate';
 import Feature from 'ol/Feature';
+import { Overlay } from 'ol';
 import OverlayPositioning from 'ol/OverlayPositioning';
-import { Popup, Template } from './Popup';
+import { Select } from 'ol/interaction';
+
+
+/** Template attributes for popup
+ * @typedef {Object} TemplateAttributes
+ * @property {string} title
+ * @property {function} format a function that takes an attribute and a feature and returns the formated attribute
+ * @property {string} before string to instert before the attribute (prefix)
+ * @property {string} after string to instert after the attribute (sudfix)
+ * @property {boolean|function} visible boolean or a function (feature, value) that decides the visibility of a attribute entry
+ */
+export declare type TemplateAttributes = {
+    title?: string;
+    format?: (val: any, feature?: Feature) => any;
+    before?: string;
+    after?: string;
+    visible?: boolean | ((feature: Feature, val: any) => boolean);
+};
+
+/** Template
+ * @typedef {Object} Template
+ * @property {string|function} title title of the popup, attribute name or a function that takes a feature and returns the title
+ * @property {Object.<TemplateAttributes>} attributes a list of template attributes
+ */
+export declare type Template = {
+    title?: string | ((feature: Feature) => string);
+    attributes?: {
+        [key: string]: TemplateAttributes;
+    };
+};
 
 export interface Options {
     popupClass?: string;
@@ -9,8 +39,10 @@ export interface Options {
     onclose?: ((...params: any[]) => any) ;
     onshow?: ((...params: any[]) => any);
     offsetBox?: number | number[];
-    positionning?: OverlayPositioning | string;
+    positioning?: OverlayPositioning | string;
     template?: Template;
+    select?: Select;
+    keepSelection?: boolean;
     canFix?: boolean;
     showImage?: boolean;
     maxChar?: boolean;
@@ -19,7 +51,7 @@ export interface Options {
  * A popup element to be displayed on a feature.
  *
  * @constructor
- * @extends {Overlay.Popup}
+ * @extends {Overlay}
  * @param {} options Extend Popup options
  *  @param {String} options.popupClass the a export class of the overlay to style the popup.
  *  @param {bool} options.closeBox popup has a close box, default false.
@@ -34,7 +66,7 @@ export interface Options {
  *  @param {boolean} options.maxChar max char to display in a cell, default 200
  *  @api stable
  */
-export class PopupFeature{ // we cannot use extends beacuse show breaks polymorphism
+export default class PopupFeature extends Overlay { // we cannot use extends Popup, because show breaks polymorphism
     constructor(options?: Options);
     /** Set the template
      * @param {Template} template A template with a list of properties to use in the popup
@@ -54,15 +86,6 @@ export class PopupFeature{ // we cannot use extends beacuse show breaks polymorp
      * @return {boolean}
      */
     getFix(): boolean;
-    /** Get a function to use as format to get local string for an attribute
-     * if the attribute is a number: Number.toLocaleString()
-     * if the attribute is a date: Date.toLocaleString()
-     * otherwise the attibute itself
-     * @param {string} locales string with a BCP 47 language tag, or an array of such strings
-     * @param {*} options Number or Date toLocaleString options
-     * @return {function} a function that takes an attribute and return the formated attribute
-     */
-    static localString(locales: string, options: Intl.DateTimeFormatOptions| Intl.NumberFormatOptions): ( a: any) => any;
     /**
      * Set a close box to the popup.
      * @param {bool} b
@@ -104,3 +127,13 @@ export class PopupFeature{ // we cannot use extends beacuse show breaks polymorp
      */
     hide(): void;
 }
+
+/** Get a function to use as format to get local string for an attribute
+ * if the attribute is a number: Number.toLocaleString()
+ * if the attribute is a date: Date.toLocaleString()
+ * otherwise the attibute itself
+ * @param {string} locales string with a BCP 47 language tag, or an array of such strings
+ * @param {*} options Number or Date toLocaleString options
+ * @return {function} a function that takes an attribute and return the formated attribute
+ */
+export function ol_Overlay_PopupFeature_localString(locales?: string | string[], options?: Intl.DateTimeFormatOptions | Intl.NumberFormatOptions): (a: any) => any;

--- a/examples/popup/map.popup.feature.ts
+++ b/examples/popup/map.popup.feature.ts
@@ -1,0 +1,114 @@
+import { Map, View } from 'ol';
+import { Tile, Vector } from 'ol/layer';
+import { Stamen, Vector as VectorSource } from 'ol/source';
+import { defaults as interaction_defaults } from 'ol/interaction';
+import { GeoJSON } from 'ol/format';
+import { Style, RegularShape, Stroke, Text, Fill } from 'ol/style';
+import { Select } from 'ol/interaction';
+import Feature from 'ol/Feature';
+import { singleClick } from 'ol/events/condition';
+
+import PopupFeature, { ol_Overlay_PopupFeature_localString as localString } from 'ol-ext/overlay/PopupFeature';
+
+// Layers
+const stamen = new Tile({
+    source: new Stamen({ layer: 'terrain' })
+});
+stamen.set('title', 'terrain-background');
+
+const layers = [stamen];
+
+// The map
+const map = new Map({
+    target: 'map',
+    view: new View({
+        zoom: 5,
+        center: [166326, 5992663]
+    }),
+    interactions: interaction_defaults({ altShiftDragRotate:false, pinchRotate:false }),
+    layers: layers
+});
+
+// GeoJSON layer
+const vectorSource = new VectorSource({
+    url: '../data/departements.geojson',
+    format: new GeoJSON(),
+    attributions: [ "&copy; <a href='https://www.insee.fr'>INSEE</a>", "&copy; <a href='https://www.data.gouv.fr/fr/datasets/geofla-r/'>IGN</a>" ],
+});
+
+const vector = new Vector({
+    source: vectorSource,
+    style: function(f) {
+        return new Style({
+            image: new RegularShape({
+                radius: 5,
+                radius2: 0,
+                points: 4,
+                stroke: new Stroke({ color: "#000", width:1 })
+            }),
+            text: new Text ({
+                text: f.get('id').toString(),
+                font: 'bold 11px sans-serif',
+            }),
+            stroke: new Stroke({
+                width: 1,
+                color: [255,128,0]
+            }),
+            fill: new Fill({
+                color: [255,128,0,.2]
+            })
+        })
+    }
+});
+vector.set('name', 'Departements');
+map.addLayer(vector);
+
+// Select  interaction
+const select = new Select({
+    hitTolerance: 5,
+    multi: true,
+    condition: singleClick
+});
+map.addInteraction(select);
+
+// Select control
+const popup = new PopupFeature({
+    popupClass: 'default anim',
+    select: select,
+    canFix: true,
+    template: {
+        title:
+        // 'nom',   // only display the name
+            function(f: Feature) {
+                return f.get('nom')+' ('+f.get('id')+')';
+            },
+        attributes: // [ 'region', 'arrond', 'cantons', 'communes', 'pop' ]
+            {
+                'region': { title: 'Région' },
+                'arrond': { title: 'Arrondissement' },
+                'cantons': { title: 'Cantons' },
+                'communes': { title: 'Communes' },
+                // with prefix and suffix
+                'pop': {
+                    title: 'Population',  // attribute's title
+                    before: '',           // something to add before
+                    format: localString(),  // format as local string
+                    after: ' hab.'        // something to add after
+                },
+                // calculated attribute
+                'pop2': {
+                    title: 'Population (kHab.)',  // attribute's title
+                    format: function(val: string, f: any) {
+                        return Math.round(parseInt(f.get('pop'))/100).toLocaleString() + ' kHab.'
+                    }
+                }
+                /* Using localString with a date * /
+                'date': { 
+                  title: 'Date', 
+                  format: PopupFeature.localString(undefined, { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }) 
+                }
+                /**/
+            }
+    }
+});
+map.addOverlay (popup);

--- a/examples/popup/map.popup.ts
+++ b/examples/popup/map.popup.ts
@@ -3,15 +3,15 @@ import { Tile, Vector } from 'ol/layer';
 import { Stamen, Vector as VectorSource } from 'ol/source';
 import { GeoJSON } from 'ol/format';
 import { Style, Icon } from 'ol/style';
-import { Select } from 'ol/interaction'
+import { Select } from 'ol/interaction';
 
-import { Popup } from 'ol-ext/overlay/Popup'
+import Popup from 'ol-ext/overlay/Popup';
 
 // Layers
 const stamen = new Tile({
     source: new Stamen({ layer: 'terrain' })
 });
-stamen.set('title', 'terrain-background')
+stamen.set('title', 'terrain-background');
 
 const layers = [stamen];
 


### PR DESCRIPTION
Supports #35.

Here is the summary:
- Recover `default` and extend `Overlay` instead of `ol_Overlay` on `Popup` and `PopupFeature` like other `overlay` classes.
- Move Template definitions from `Popup` to `PopupFeature` like original ol-ext source code.
- Move `PopupFeature.localString` static method outside of `PopupFeature` class, because the example didn't detect that at runtime.