### PR TITLE
Animated cluster

### DIFF
--- a/@types/ol-ext/interaction/SelectCluster.d.ts
+++ b/@types/ol-ext/interaction/SelectCluster.d.ts
@@ -1,14 +1,14 @@
 import { Map as _ol_Map_ } from 'ol';
 import Feature, { FeatureLike } from 'ol/Feature';
 import { Vector } from 'ol/layer';
-import { Style } from 'ol/style';
+import { StyleLike } from 'ol/style/Style';
 import { Select } from 'ol/interaction';
 import { Coordinate } from 'ol/coordinate';
 
 export interface Options {
-    featureStyle: Style;
+    featureStyle: StyleLike;
     selectCluster: boolean;
-    PointRadius: number;
+    pointRadius: number;
     spiral: boolean;
     circleMaxObject: number;
     maxObjects: number;
@@ -26,9 +26,9 @@ export interface Options {
  * @constructor
  * @extends {interaction.Select}
  * @param {olx.interaction.SelectOptions=} options SelectOptions.
- *  @param {style} options.featureStyle used to style the revealed features as options.style is used by the Select interaction.
+ *  @param {StyleLike} options.featureStyle used to style the revealed features as options.style is used by the Select interaction.
  * 	@param {boolean} options.selectCluster false if you don't want to get cluster selected
- * 	@param {Number} options.PointRadius to calculate distance between the features
+ * 	@param {Number} options.pointRadius to calculate distance between the features
  * 	@param {bool} options.spiral means you want the feature to be placed on a spiral (or a circle)
  * 	@param {Number} options.circleMaxObject number of object that can be place on a circle
  * 	@param {Number} options.maxObjects number of object that can be drawn, other are hidden

--- a/@types/ol-ext/interaction/SelectCluster.d.ts
+++ b/@types/ol-ext/interaction/SelectCluster.d.ts
@@ -4,29 +4,17 @@ import { Vector } from 'ol/layer';
 import { StyleLike } from 'ol/style/Style';
 import { Select } from 'ol/interaction';
 import { Coordinate } from 'ol/coordinate';
-<<<<<<< HEAD
+import { Extent } from 'ol/extent';
 import { Options as SelectOptions } from 'ol/interaction/Select'
 
 export interface Options extends SelectOptions {
-    featureStyle: StyleLike;
-    selectCluster?: boolean;
-    pointRadius: number;
-    spiral?: boolean;
-    circleMaxObject?: number;
-    maxObjects?: number;
-    animate: boolean;
-=======
-import { Extent } from 'ol/extent';
-
-export interface Options {
-    featureStyle?: Style;
+    featureStyle?: StyleLike;
     selectCluster?: boolean;
     pointRadius?: number;
     spiral?: boolean;
     circleMaxObject?: number;
     maxObjects?: number;
     animate?: boolean;
->>>>>>> pub/master
     animationDuration?: number;
 }
 /**
@@ -40,11 +28,7 @@ export interface Options {
  * @constructor
  * @extends {ol.interaction.Select}
  * @param {olx.interaction.SelectOptions=} options SelectOptions.
-<<<<<<< HEAD
- *  @param {StyleLike} options.featureStyle used to style the revealed features as options.style is used by the Select interaction.
-=======
- *  @param {ol.style} options.featureStyle used to style the revealed features as options.style is used by the Select interaction.
->>>>>>> pub/master
+ *  @param {ol.style.StyleLike} options.featureStyle used to style the revealed features as options.style is used by the Select interaction.
  * 	@param {boolean} options.selectCluster false if you don't want to get cluster selected
  * 	@param {Number} options.pointRadius to calculate distance between the features
  * 	@param {bool} options.spiral means you want the feature to be placed on a spiral (or a circle)

--- a/@types/ol-ext/interaction/SelectCluster.d.ts
+++ b/@types/ol-ext/interaction/SelectCluster.d.ts
@@ -4,16 +4,17 @@ import { Vector } from 'ol/layer';
 import { StyleLike } from 'ol/style/Style';
 import { Select } from 'ol/interaction';
 import { Coordinate } from 'ol/coordinate';
+import { Options as SelectOptions } from 'ol/interaction/Select'
 
-export interface Options {
+export interface Options extends SelectOptions {
     featureStyle: StyleLike;
-    selectCluster: boolean;
+    selectCluster?: boolean;
     pointRadius: number;
-    spiral: boolean;
-    circleMaxObject: number;
-    maxObjects: number;
-    animation: boolean;
-    animationDuration: number;
+    spiral?: boolean;
+    circleMaxObject?: number;
+    maxObjects?: number;
+    animate: boolean;
+    animationDuration?: number;
 }
 /**
  * @classdesc
@@ -32,7 +33,7 @@ export interface Options {
  * 	@param {bool} options.spiral means you want the feature to be placed on a spiral (or a circle)
  * 	@param {Number} options.circleMaxObject number of object that can be place on a circle
  * 	@param {Number} options.maxObjects number of object that can be drawn, other are hidden
- * 	@param {bool} options.animation if the cluster will animate when features spread out, default is false
+ * 	@param {bool} options.animate if the cluster will animate when features spread out, default is false
  * 	@param {Number} options.animationDuration animation duration in ms, default is 500ms
  * @fires interaction.SelectEvent
  * @api stable

--- a/@types/ol-ext/layer/AnimatedCluster.d.ts
+++ b/@types/ol-ext/layer/AnimatedCluster.d.ts
@@ -14,5 +14,5 @@ interface ClusterOptions extends Options {
  *  @param {ol.easingFunction} animationMethod easing method to use, default ol.easing.easeOut
  */
 export default class AnimatedCluster extends VectorLayer {
-    constructor(param: ClusterOptions);
+    constructor(options?: ClusterOptions);
 }

--- a/@types/ol-ext/layer/AnimatedCluster.d.ts
+++ b/@types/ol-ext/layer/AnimatedCluster.d.ts
@@ -1,0 +1,11 @@
+import VectorLayer from 'ol/layer/Vector';
+import { Options } from 'ol/layer/BaseVector';
+
+interface ClusterOptions extends Options {
+    animationDuration?: number;
+    easingFunction: (t: number) => number;
+}
+
+export default class AnimatedCluster extends VectorLayer {
+    constructor(param: ClusterOptions);
+}

--- a/@types/ol-ext/layer/AnimatedCluster.d.ts
+++ b/@types/ol-ext/layer/AnimatedCluster.d.ts
@@ -5,7 +5,14 @@ interface ClusterOptions extends Options {
     animationDuration?: number;
     easingFunction?: (t: number) => number;
 }
-
+/**
+ *  A vector layer for animated cluster
+ * @constructor 
+ * @extends {ol.layer.Vector}
+ * @param {olx.layer.AnimatedClusterOptions=} options extend olx.layer.Options
+ *  @param {Number} options.animationDuration animation duration in ms, default is 700ms 
+ *  @param {ol.easingFunction} animationMethod easing method to use, default ol.easing.easeOut
+ */
 export default class AnimatedCluster extends VectorLayer {
     constructor(param: ClusterOptions);
 }

--- a/@types/ol-ext/layer/AnimatedCluster.d.ts
+++ b/@types/ol-ext/layer/AnimatedCluster.d.ts
@@ -3,7 +3,7 @@ import { Options } from 'ol/layer/BaseVector';
 
 interface ClusterOptions extends Options {
     animationDuration?: number;
-    easingFunction: (t: number) => number;
+    easingFunction?: (t: number) => number;
 }
 
 export default class AnimatedCluster extends VectorLayer {

--- a/@types/ol-ext/overlay/Tooltip.d.ts
+++ b/@types/ol-ext/overlay/Tooltip.d.ts
@@ -3,7 +3,7 @@ import { Coordinate } from 'ol/coordinate';
 import Feature from 'ol/Feature';
 import Event from 'ol/events/Event';
 import OverlayPositioning from 'ol/OverlayPositioning';
-import { Popup } from './Popup';
+import Popup from './Popup';
 
 export interface Options {
     popupClass?: string;


### PR DESCRIPTION
Adds types for `AnimatedCluster` and fixes some other wrong types:
`SelectCluster` should take StyleLike for style, not Style
Options should extend Select's constructor options:
```ts
import { Options as SelectOptions } from 'ol/interaction/Select'

export interface Options extends SelectOptions {
```