### PR TITLE
WIP Update to ol 7 and ol-ext 4

### DIFF
--- a/@types/ol-ext/control/WMSCapabilities.d.ts
+++ b/@types/ol-ext/control/WMSCapabilities.d.ts
@@ -3,7 +3,6 @@ import TileLayer from 'ol/layer/Tile';
 import Button from './Button';
 import { Options as ControlOptions } from 'ol/control/Control';
 import Dialog from './Dialog';
-import Layer from '../filter/Base';
 import { Extent } from 'ol/extent';
 import TileSource from 'ol/source/Tile';
 

--- a/@types/ol-ext/featureanimation/FeatureAnimation.d.ts
+++ b/@types/ol-ext/featureanimation/FeatureAnimation.d.ts
@@ -1,13 +1,13 @@
 import { Style } from 'ol/style'
 import { FeatureLike } from 'ol/Feature';
 import { Geometry } from 'ol/geom';
-import GeometryType from 'ol/geom/GeometryType';
 import { Extent } from 'ol/extent';
 import { Coordinate } from 'ol/coordinate';
-import { FrameState } from 'ol/PluggableMap';
 import VectorContext from 'ol/render/VectorContext';
 import { StyleLike } from 'ol/style/Style';
 import { Object as _OL_OBJECT } from 'ol';
+import { Type } from 'ol/geom/Geometry';
+import { FrameState } from 'ol/Map';
 
 export interface FeatureAnimationEvent {
     vectorContext: VectorContext,
@@ -19,7 +19,7 @@ export interface FeatureAnimationEvent {
     // Feature information
     feature: FeatureLike,
     geom: Geometry
-    typeGeom: typeof GeometryType,
+    typeGeom:  Type,
     bbox: Extent
     coord: Coordinate
     style: StyleLike

--- a/@types/ol-ext/interaction/DrawTouch.d.ts
+++ b/@types/ol-ext/interaction/DrawTouch.d.ts
@@ -2,12 +2,12 @@ import { Map as _ol_Map_ } from 'ol';
 import { Coordinate } from 'ol/coordinate';
 import { Vector as VectorSource } from 'ol/source';
 import { Style } from 'ol/style';
-import GeometryType from 'ol/geom/GeometryType';
 import CenterTouch from './CenterTouch';
+import { Type } from 'ol/geom/Geometry';
 
 export interface Options {
     source?: VectorSource;
-    type: typeof GeometryType.POINT | typeof GeometryType.LINE_STRING | typeof GeometryType.POLYGON;
+    type: 'Point'| 'LineString' | 'Polygon'
     tap?: boolean;
     style?: Style | Style[];
     sketchStyle?: Style | Style[];
@@ -48,7 +48,7 @@ export interface Options {
     /** Get geometry type
     * @return {GeometryType}
      */
-    getGeometryType(): typeof GeometryType;
+    getGeometryType(): Type;
     /** Start drawing and add the sketch feature to the target layer.
     * The interaction.Draw.EventType.DRAWEND event is dispatched before inserting the feature.
      */

--- a/@types/ol-ext/interaction/GeolocationDraw.d.ts
+++ b/@types/ol-ext/interaction/GeolocationDraw.d.ts
@@ -1,11 +1,11 @@
 import { Map as _ol_Map_ } from 'ol';
 import { Vector as VectorSource } from 'ol/source';
 import { StyleLike } from 'ol/style/Style';
-import GeometryType from 'ol/geom/GeometryType';
 import { Interaction } from 'ol/interaction';
 import { Coordinate } from 'ol/coordinate';
 import { Geolocation as _ol_Geolocation } from 'ol';
 import { Geometry, LineString, Polygon } from 'ol/geom';
+import { Type } from 'ol/geom/Geometry';
 import BaseEvent from 'ol/events/Event';
 import Feature from 'ol/Feature';
 import { EventsKey } from 'ol/events';
@@ -14,10 +14,10 @@ import { CombinedOnSignature, EventTypes, OnSignature } from 'ol/Observable';
 import { Types } from 'ol/ObjectEventType';
 
 type GeolocationDrawOnSignature<Return> = OnSignature<EventTypes, Event, Return> &
-  OnSignature<Types | 'change' | 'change:active' | 'error' | 'propertychange', ObjectEvent, Return> &
-  OnSignature<Types | 'drawing' | 'tracking', GeolocationDrawEvent, Return> &
-  OnSignature<Types | 'following', FollowingEvent, Return> &
-  CombinedOnSignature<Types | EventTypes | 'change' | 'change:active' | 'error' | 'propertychange' | 'drawing' | 'tracking' | 'following', Return>;
+    OnSignature<Types | 'change' | 'change:active' | 'error' | 'propertychange', ObjectEvent, Return> &
+    OnSignature<Types | 'drawing' | 'tracking', GeolocationDrawEvent, Return> &
+    OnSignature<Types | 'following', FollowingEvent, Return> &
+    CombinedOnSignature<Types | EventTypes | 'change' | 'change:active' | 'error' | 'propertychange' | 'drawing' | 'tracking' | 'following', Return>;
 
 export enum GeolocationDrawEventType {
     DRAWING = 'drawing',
@@ -34,7 +34,7 @@ export interface Attributes {
 
 export interface GeolocationDrawOptions {
     source?: VectorSource;
-    type?: typeof GeometryType.POINT | typeof GeometryType.LINE_STRING | typeof GeometryType.POLYGON;
+    type?: 'Point' | 'LineString' | 'Polygon';
     minAccuracy?: number;
     condition?: ((loc: _ol_Geolocation) => boolean);
     attributes?: Attributes;

--- a/@types/ol-ext/interaction/Hover.d.ts
+++ b/@types/ol-ext/interaction/Hover.d.ts
@@ -4,7 +4,6 @@ import Event from 'ol/events/Event';
 import Feature from 'ol/Feature';
 import { Layer } from 'ol/layer';
 import BaseEvent from 'ol/events/Event';
-import Collection from 'ol/Collection';
 import { Pixel } from 'ol/pixel';
 import { Coordinate } from 'ol/coordinate';
 import { Geometry } from 'ol/geom';

--- a/@types/ol-ext/interaction/ModifyFeature.d.ts
+++ b/@types/ol-ext/interaction/ModifyFeature.d.ts
@@ -3,7 +3,6 @@ import Collection from 'ol/Collection';
 import { Coordinate } from 'ol/coordinate';
 import Feature from 'ol/Feature';
 import { Style } from 'ol/style';
-import GeometryType from 'ol/geom/GeometryType';
 import { Pointer } from 'ol/interaction';
 import MapBrowserEvent from 'ol/MapBrowserEvent';
 import { Condition as EventsConditionType } from 'ol/events/condition';
@@ -11,14 +10,14 @@ import { Vector as VectorSource } from 'ol/source';
 import { EventsKey } from 'ol/events';
 import BaseEvent from 'ol/events/Event';
 import { ObjectEvent } from 'ol/Object';
-import Geometry from 'ol/geom/Geometry';
+import Geometry, { Type } from 'ol/geom/Geometry';
 import { CombinedOnSignature, EventTypes, OnSignature } from 'ol/Observable';
 import { Types } from 'ol/ObjectEventType';
 
 type ModifyFeatureOnSignature<Return> = OnSignature<EventTypes, Event, Return> &
-  OnSignature<Types | 'change' | 'change:active' | 'error' | 'propertychange', ObjectEvent, Return> &
-  OnSignature<Types | 'modifyend' | 'modifystart' | 'modifying', ModifyEvent, Return> &
-  CombinedOnSignature<Types | EventTypes | 'change' | 'change:active' | 'error' | 'propertychange' | 'modifyend' | 'modifystart' | 'modifying', Return>;
+    OnSignature<Types | 'change' | 'change:active' | 'error' | 'propertychange', ObjectEvent, Return> &
+    OnSignature<Types | 'modifyend' | 'modifystart' | 'modifying', ModifyEvent, Return> &
+    CombinedOnSignature<Types | EventTypes | 'change' | 'change:active' | 'error' | 'propertychange' | 'modifyend' | 'modifystart' | 'modifying', Return>;
 
 export enum ModifyingEventType {
     MODIFYING = 'modifying'
@@ -84,21 +83,22 @@ export default class ModifyFeature extends Pointer {
     setFilter(filter?: (f: Feature) => boolean): void
 
     /** Get nearest coordinate in a list
-    * @param {Coordinate} pt the point to find nearest
-    * @param {geom} coords list of coordinates
-    * @return {*} the nearest point with a coord (projected point), dist (distance to the geom), ring (if Polygon)
-     */
-    getNearestCoord(pt: Coordinate, coords: typeof GeometryType): {
+   * @param {ol.coordinate} pt the point to find nearest
+   * @param {ol.geom} geom Geometry
+   * @return {*} the nearest point with a coord (projected point), dist (distance to the geom), ring (if Polygon)
+   */
+    getNearestCoord(pt: Coordinate, geom: Type): {
         coord: Coordinate,
         dist: number,
         ring?: number
         pt?: Coordinate,
     } | false;
+    
     /** Get arcs concerned by a modification
      * @param {geom} geom the geometry concerned
      * @param {Coordinate} coord pointed coordinates
      */
-    getArcs(geom: typeof GeometryType, coord: Coordinate): void;
+    getArcs(geom: Type, coord: Coordinate): void;
     /**
      * @param {MapBrowserEvent<UIEvent>} evt Map browser event.
      * @return {boolean} `true` to start the drag sequence.

--- a/@types/ol-ext/interaction/ModifyTouch.d.ts
+++ b/@types/ol-ext/interaction/ModifyTouch.d.ts
@@ -1,6 +1,5 @@
 import { Map as _ol_Map_ } from 'ol';
 import { Modify } from 'ol/interaction';
-import OverlayPositioning from 'ol/OverlayPositioning';
 import BaseEvent from 'ol/events/Event';
 import Feature from 'ol/Feature';
 import { Coordinate } from 'ol/coordinate';
@@ -9,6 +8,7 @@ import { ObjectEvent } from 'ol/Object';
 import { ModifyEvent } from 'ol/interaction/Modify';
 import { CombinedOnSignature, EventTypes, OnSignature } from 'ol/Observable';
 import { Types } from 'ol/ObjectEventType';
+import Positioning from 'ol/Overlay';
 
 type ModifyTouchOnSignature<Return> = OnSignature<EventTypes, Event, Return> &
   OnSignature<Types | 'change' | 'change:active' | 'error' | 'propertychange', ObjectEvent, Return> &
@@ -23,7 +23,7 @@ export enum PopupEventType {
 export interface Options {
     title?: string;
     className?: string;
-    positioning?: typeof OverlayPositioning;
+    positioning?: Positioning;
     offsetBox?: number | number[];
     usePopup?: boolean;
 }

--- a/@types/ol-ext/interaction/Offset.d.ts
+++ b/@types/ol-ext/interaction/Offset.d.ts
@@ -1,7 +1,7 @@
 import { Map as _ol_Map_ } from 'ol';
 import Collection from 'ol/Collection';
 import Feature from 'ol/Feature';
-import { Vector } from 'ol/layer';
+import { Layer, Vector } from 'ol/layer';
 import { Vector as VectorSource } from 'ol/source';
 import { Pointer } from 'ol/interaction';
 import { StyleLike } from 'ol/style/Style';

--- a/@types/ol-ext/interaction/Ripple.d.ts
+++ b/@types/ol-ext/interaction/Ripple.d.ts
@@ -1,6 +1,5 @@
 import { Pointer } from 'ol/interaction';
 import MapBrowserEvent from 'ol/MapBrowserEvent';
-import { Color } from 'ol/color';
 import { Pixel } from 'ol/pixel';
 import { Layer } from 'ol/layer';
 

--- a/@types/ol-ext/interaction/TouchCursorDraw.d.ts
+++ b/@types/ol-ext/interaction/TouchCursorDraw.d.ts
@@ -2,18 +2,18 @@ import { TouchCursor } from "./TouchCursor";
 import { Coordinate } from 'ol/coordinate';
 import { InteractionOptions } from "ol/interaction/Interaction";
 import  Button  from "../control/Button";
-import GeometryType from 'ol/geom/GeometryType';
 import VectorSource from 'ol/source/Vector';
 import Collection from 'ol/Collection';
 import { Feature, Map as _ol_Map_ } from 'ol';
 import { StyleLike } from 'ol/style/Style';
+import { Type } from "ol/geom/Geometry";
 
 export interface Options extends InteractionOptions {
     className?: string;
     coordinate?: Coordinate;
     buttons?: Button[];
     maxButtons?: number;
-    type?: typeof GeometryType;
+    type?: Type;
     types?: string[];
     source?: VectorSource;
     features?: Collection<Feature>;

--- a/@types/ol-ext/overlay/FixedPopup.d.ts
+++ b/@types/ol-ext/overlay/FixedPopup.d.ts
@@ -2,7 +2,7 @@ import { Map as _ol_Map_, Overlay } from 'ol';
 
 import { Pixel } from 'ol/pixel';
 import { Style } from 'ol/style';
-import OverlayPositioning from 'ol/OverlayPositioning';
+import Positioning from 'ol/Overlay';
 import { Options as OverlayOptions } from 'ol/Overlay';
 import Popup from './Popup';
 export interface Options extends OverlayOptions {
@@ -14,7 +14,7 @@ export interface Options extends OverlayOptions {
     onClose?: () => void;
     onShow?: () => void;
     offsetBox?: number | number[];
-    positioning?: typeof OverlayPositioning | any | undefined; // workaround with any for 'auto'
+    positioning?: typeof Positioning | any | undefined; // workaround with any for 'auto'
 }
 
 /**

--- a/@types/ol-ext/overlay/Popup.d.ts
+++ b/@types/ol-ext/overlay/Popup.d.ts
@@ -1,7 +1,6 @@
-import { Overlay as Overlay } from 'ol';
+import { Overlay } from 'ol';
 import { Coordinate } from 'ol/coordinate';
-import { Options as OverlayOptions } from 'ol/Overlay';
-import OverlayPositioning from 'ol/OverlayPositioning';
+import { Options as OverlayOptions, Positioning } from 'ol/Overlay';
 
 
 /** Openlayers Overlay.
@@ -9,8 +8,6 @@ import OverlayPositioning from 'ol/OverlayPositioning';
  * @namespace Overlay
  * @see {@link http://openlayers.org/en/latest/apidoc/module-ol_Overlay.html}
  */
-
-
 export interface Options extends OverlayOptions {
     popupClass?: string;
     anim?: boolean;
@@ -18,9 +15,9 @@ export interface Options extends OverlayOptions {
     onclose?: () => void;
     onshow?: () => void;
     offsetBox?: number | number[];
-    positioning?: typeof OverlayPositioning | any | undefined; // workaround with any for 'auto'
+    positioning?: Positioning | any | undefined; // workaround with any for 'auto'
+    minibar?: boolean;
 }
-
 
 
 /**
@@ -82,7 +79,7 @@ export default class Popup extends Overlay {
      * 		or 'auto' to var the popup choose the best position
      * @api stable
      */
-    setPositioning(pos?: typeof OverlayPositioning | string): void;
+    setPositioning(pos?: Positioning | string): void;
     /** Check if popup is visible
     * @return {boolean}
      */

--- a/@types/ol-ext/overlay/PopupFeature.d.ts
+++ b/@types/ol-ext/overlay/PopupFeature.d.ts
@@ -1,8 +1,8 @@
 import { Coordinate } from 'ol/coordinate';
 import Feature from 'ol/Feature';
 import { Overlay } from 'ol';
-import OverlayPositioning from 'ol/OverlayPositioning';
 import { Select } from 'ol/interaction';
+import { Positioning } from 'ol/Overlay';
 
 
 /** Template attributes for popup
@@ -39,7 +39,7 @@ export interface Options {
     onclose?: ((...params: any[]) => any);
     onshow?: ((...params: any[]) => any);
     offsetBox?: number | number[];
-    positioning?: typeof OverlayPositioning | string;
+    positioning?: Positioning | string;
     template?: Template | ((f: Feature) => Template);
     select?: Select;
     keepSelection?: boolean;
@@ -122,7 +122,7 @@ export default class PopupFeature extends Overlay { // we cannot use extends Pop
      * 		or 'auto' to var the popup choose the best position
      * @api stable
      */
-    setPositioning(pos: typeof OverlayPositioning | string | undefined): void;
+    setPositioning(pos: Positioning | string | undefined): void;
     /** Check if popup is visible
     * @return {boolean}
      */

--- a/@types/ol-ext/overlay/Tooltip.d.ts
+++ b/@types/ol-ext/overlay/Tooltip.d.ts
@@ -2,8 +2,8 @@ import { Map as _ol_Map_ } from 'ol';
 import { Coordinate } from 'ol/coordinate';
 import Feature from 'ol/Feature';
 import Event from 'ol/events/Event';
-import OverlayPositioning from 'ol/OverlayPositioning';
 import Popup from './Popup';
+import { Positioning } from 'ol/Overlay';
 
 export interface Options {
     popupClass?: string;
@@ -12,7 +12,7 @@ export interface Options {
     formatArea?: (area: number) => string;
     getHTML?: (feature: Feature, info: string) => string;
     offsetBox?: number | number[];
-    positionning?: typeof OverlayPositioning | string ;
+    Positioning?: Positioning | string;
 }
 /** A tooltip element to be displayed over the map and attached on the cursor position.
  * @constructor
@@ -103,7 +103,7 @@ export default class Tooltip extends Popup {
      * 		or 'auto' to var the popup choose the best position
      * @api stable
      */
-    setPositioning(pos?: typeof OverlayPositioning | string): void;
+    setPositioning(pos?: Positioning | string): void;
     /** Check if popup is visible
     * @return {boolean}
      */

--- a/@types/ol-ext/source/Geoportail.d.ts
+++ b/@types/ol-ext/source/Geoportail.d.ts
@@ -1,4 +1,4 @@
-import { WMTS} from 'ol/source/WMTS';
+import WMTS from 'ol/source/WMTS';
 import { Options as SourceOptions } from 'ol/source/TileImage';
 import { Coordinate } from 'ol/coordinate';
 import { ProjectionLike } from 'ol/proj';

--- a/@types/ol-ext/style/FillPattern.d.ts
+++ b/@types/ol-ext/style/FillPattern.d.ts
@@ -76,7 +76,7 @@ export default class FillPattern extends Fill {
   /** Patterns definitions
    * @see pattern generator http://www.imagico.de/map/jsdotpattern.php
    */
-  patterns: {
+  static patterns: {
     hatch: {
       width: number;
       height: number;

--- a/@types/ol-ext/style/FontSymbol.d.ts
+++ b/@types/ol-ext/style/FontSymbol.d.ts
@@ -39,6 +39,11 @@ export interface Glyph {
     search: string
 }
 
+export interface FontDefs {
+    fonts: { [key:string]: Font },
+    glyphs: { [key:string]: Glyph }
+}
+
 /**
  * @classdesc
  * A marker style to use with font symbols.
@@ -75,10 +80,7 @@ export default class FontSymbol extends RegularShape {
     /**
      *	Font defs
      */
-    defs: {
-        fonts: any;
-        glyphs: any;
-    };
+    static defs: FontDefs;
     /** Static function : add new font defs
      * @param {String|Object} font the font desciption
      * @param {} glyphs a key / value list of glyph definitions.

--- a/@types/ol-ext/util/TextStreamReader.d.ts
+++ b/@types/ol-ext/util/TextStreamReader.d.ts
@@ -33,11 +33,11 @@ export default class TextStreamReader {
      * @param {function} getLine a function that gets the current line as argument. Return false to stop reading
      * @param {function} [progress] a function that gets the progress on each chunk (beetween 0,1) and a boolean set to true on end
      */
-    readLines(getLine: (line: string) => void, progress?: (number, boolean) => void): void;
+    readLines(getLine: (line: string) => void, progress?: (arg0: number, arg1: boolean) => void): void;
     /** Read a set of line chunk from the stream
      * @param {function} getLines a function that gets lines read as an Array<String>.
      * @param {function} [progress] a function that gets the progress (beetween 0,1) and a boolean set to true on end of file
      */
-    readChunk(getLines: (lines: string[]) => void, progress?: (number, boolean) => void): void
+    readChunk(getLines: (lines: string[]) => void, progress?: (arg0: number, arg1: boolean) => void): void
 
 }

--- a/@types/ol-ext/util/View.d.ts
+++ b/@types/ol-ext/util/View.d.ts
@@ -37,8 +37,8 @@ export interface viewTourDestinations {
     /**
      * Optional anchor to remain fixed during a rotation or resolution animation.
      */
-    anchor?: anchor;
-};
+    anchor?: Coordinate;
+}
 
 export type Destination = {
     x: number,

--- a/@types/ol-ext/util/Worker.d.ts
+++ b/@types/ol-ext/util/Worker.d.ts
@@ -1,4 +1,3 @@
-export default ol_ext_Worker;
 /** Worker helper to create a worker from code
  * @constructor
  * @param {function} mainFn main worker function

--- a/@types/ol-ext/util/input/Collection.d.ts
+++ b/@types/ol-ext/util/input/Collection.d.ts
@@ -1,9 +1,9 @@
+import { Feature } from 'ol';
 import ol_Collection from 'ol/Collection';
 export interface Options<T> {
     target?: Element;
     collection?: ol_Collection<T> //todo unsure
     getTitle?: (elt: any) => Element | string
-
 }
 
 
@@ -46,7 +46,7 @@ export default class Collection<T>{
     /** Set the collection
   * @param {ol_Collection} collection
   */
-    setCollection(collection: Collection): void
+    setCollection(collection: Collection<T>): void
 
     /** Remove current collection (listeners)
      * /!\ remove collection when input list is removed from the DOM

--- a/examples/animation/map.featureanimation.ts
+++ b/examples/animation/map.featureanimation.ts
@@ -9,6 +9,15 @@ import { LineString, Point, Polygon } from 'ol/geom';
 import { Coordinate } from 'ol/coordinate';
 import 'ol-ext/render/AnimExtent';
 import featureAnimation from 'ol-ext/featureanimation/FeatureAnimation';
+
+declare global {
+  interface Window {
+    $(selector: any, context?: any): any,
+    add10(): void
+  }
+}
+const $ = window.$;
+
 // Layers
 let layer = new TileLayer({
   source: new Stamen({ layer: 'terrain' }),
@@ -112,12 +121,12 @@ function addFeatureAt(p: Coordinate) {
 
   vector.getSource()?.addFeature(f);
   vector.animateFeature(f, [
-    new featureAnimation[$('#anim').text()] ({
+    new featureAnimation[$('#anim').val()] ({
       speed: Number($('#speed').val()),
       duration: Number(1000 -Number($('#speed').val()) * 300),
       side: $('#side').prop('checked'),
     }),
-    new featureAnimation[$('#anim2').text()]({
+    new featureAnimation[$('#anim2').val()]({
       speed: Number($('#speed').val()),
       duration: Number(1000 - Number($('#speed').val()) * 300),
       horizontal: /Slide/.test($('#anim').text()),
@@ -138,6 +147,9 @@ function add10() {
     }, 100 * i);
   }
 }
+window.add10 = (): void => {
+  add10();
+}
 add10();
 
 // Drop a feature on click
@@ -153,7 +165,7 @@ map.on('singleclick', function (evt) {
     vector.getSource()?.removeFeature(f);
     // Show animation
     vector.animateFeature(f, [
-      new featureAnimation[$('#anim').text()]({
+      new featureAnimation[$('#anim').val()]({
         speed: Number($('#speed').val()),
         duration: Number(1000 - Number($('#speed').val()) * 300),
         side: $('#side').prop('checked'),

--- a/examples/control/map.control.geobookmark.ts
+++ b/examples/control/map.control.geobookmark.ts
@@ -3,6 +3,13 @@ import { Tile } from 'ol/layer';
 import { Stamen } from 'ol/source';
 import GeoBookmark from 'ol-ext/control/GeoBookmark';
 import { transform } from 'ol/proj';
+
+declare global {
+  interface Window {
+    bm: GeoBookmark
+  }
+}
+
 // The map
 var map = new Map
 	({
@@ -24,3 +31,5 @@ var bm = new GeoBookmark({
 	}
 });
 map.addControl(bm);
+
+window.bm = bm;

--- a/examples/misc/map.compare.ts
+++ b/examples/misc/map.compare.ts
@@ -75,7 +75,7 @@ map.addOverlay(popup1);
 var popup2 = new Popup({ anim: true, closeBox: true });
 map2.addOverlay(popup2);
 
-function showPopup(e: CollectionEvent, popup: Popup) {
+function showPopup(e: CollectionEvent<Feature>, popup: Popup) {
     var feature = e.element;
     var content = "";
     if (!feature.get('text')) return;

--- a/examples/misc/map.input.ts
+++ b/examples/misc/map.input.ts
@@ -8,14 +8,30 @@ import Width from 'ol-ext/util/input/Width';
 import List from 'ol-ext/util/input/List';
 import PopupBase from 'ol-ext/util/input/PopupBase';
 import { asString } from 'ol/color';
+import { Map as _ol_Map } from 'ol';
+import Dialog from 'ol-ext/control/Dialog';
+import Range from 'ol-ext/util/input/Range';
 
 declare global {
   interface Window {
     $(selector: any, context?: any): any;
     [key: string]: any;
+    dialog: Dialog;
   }
 }
 
+/* A dialog with a color input */ 
+const fakeMap = new _ol_Map();
+const dialog = new Dialog({ fullscreen: true });
+fakeMap.addControl(dialog);
+dialog.setContent({
+  title: 'Color',
+  content: 'Color : '
+});
+const inputColor = new Color({ position: 'fixed', parent: dialog.getContentElement() })
+window.dialog = dialog;
+
+/* Set inputs */
 const switcher = new Switch({
   input: $('.switch').get(0),
   html: 'off',
@@ -34,11 +50,7 @@ $('.radio').each((i: number, elem: Element) => {
     after: 'radio ' + (i + 1),
     checked: !i,
   });
-  if (i === 0) {
-    window.radio1 = radio;
-  } else {
-    window.radio2 = radio;
-  }
+  window['radio'+(i+1)] = radio;
 });
 
 const slider = new Slider({ input: $('.slider').get(0) });
@@ -122,4 +134,13 @@ arrow.on('change:value', (e) => {
 
 const popup = new PopupBase({
   input: $('.popup').get(0),
+});
+
+const range = new Range({
+  input: $('.range').get(0),
+});
+var range2 = new Range({
+  input: $('.range2').get(0),
+  input2: $('.range2').get(1),
+  overflow: true
 });

--- a/examples/popup/map.fixedpopup.ts
+++ b/examples/popup/map.fixedpopup.ts
@@ -8,8 +8,7 @@ import TileLayer from 'ol/layer/Tile';
 import FixedPopup from 'ol-ext/overlay/FixedPopup';
 import VectorLayer from 'ol/layer/Vector';
 import { LineString, Point } from 'ol/geom';
-import Fixed from '../../@types/ol-ext/overlay/Fixed';
-import Popup from '../../@types/ol-ext/overlay/Popup';
+import Popup from 'ol-ext/overlay/Popup';
 
 // Layers
 const layers = [

--- a/examples/popup/map.popup.ts
+++ b/examples/popup/map.popup.ts
@@ -1,4 +1,4 @@
-import { Map, View } from 'ol';
+import { Map, View, Feature } from 'ol';
 import { Tile, Vector } from 'ol/layer';
 import { Stamen, Vector as VectorSource } from 'ol/source';
 import { GeoJSON } from 'ol/format';
@@ -6,6 +6,7 @@ import { Style, Icon } from 'ol/style';
 import { Select } from 'ol/interaction';
 
 import Popup from 'ol-ext/overlay/Popup';
+import { Polygon } from 'ol/geom';
 
 // Layers
 const stamen = new Tile({
@@ -16,19 +17,24 @@ stamen.set('title', 'terrain-background');
 const layers = [stamen];
 
 // Popup overlay
-const popup = new Popup (
-    {	popupClass: "default", //"tooltips", "warning" "black" "default", "tips", "shadow",
+const popup = new Popup(
+    {
+        popupClass: "default", //"tooltips", "warning" "black" "default", "tips", "shadow",
         closeBox: true,
-        onshow: function(){ console.log("You opened the box"); },
-        onclose: function(){ console.log("You close the box"); },
+        onshow: function () { console.log("You opened the box"); },
+        onclose: function () { console.log("You close the box"); },
         positioning: 'auto',
         anim: true,
-        autoPan: true,
-        autoPanAnimation: { duration: 250 }
+        autoPan: {
+            animation: {
+                duration: 250
+            },
+        }
+        // autoPanAnimation: { duration: 250 }
     });
 
 // The map
-const map = new Map ({
+const map = new Map({
     target: 'map',
     view: new View({
         zoom: 5,
@@ -45,13 +51,13 @@ const vectorSource = new VectorSource({
         dataProjection: 'EPSG:4326',
         featureProjection: 'EPSG:3857'
     }),
-    attributions: [ "&copy; <a href='https://data.culture.gouv.fr/explore/dataset/fonds-de-la-guerre-14-18-extrait-de-la-base-memoire'>" +
-                    "<img src='https://data.culture.gouv.fr/assets/logo' height='12px'>data.culture.gouv.fr</a>" ]
+    attributions: ["&copy; <a href='https://data.culture.gouv.fr/explore/dataset/fonds-de-la-guerre-14-18-extrait-de-la-base-memoire'>" +
+        "<img src='https://data.culture.gouv.fr/assets/logo' height='12px'>data.culture.gouv.fr</a>"]
 });
 
 const vector = new Vector({
     source: vectorSource,
-    style: new Style({ image: new Icon({ src:"../data/camera.png", scale: 0.8 }) })
+    style: new Style({ image: new Icon({ src: "../data/camera.png", scale: 0.8 }) })
 });
 vector.set('name', 'Fonds de guerre 14-18')
 map.addLayer(vector);
@@ -61,14 +67,16 @@ const select = new Select({});
 map.addInteraction(select);
 
 // On selected => show/hide popup
-select.getFeatures().on('add', function(e) {
+select.getFeatures().on('add', function (e) {
     const feature = e.element;
     let content = "";
-    content += "<img src='"+feature.get("img")+"'/>";
+    content += "<img src='" + feature.get("img") + "'/>";
     content += feature.get("text");
-    popup.show(feature.getGeometry().getFirstCoordinate(), content);
+
+    const f = feature as Feature<Polygon>;
+    popup.show(f.getGeometry()?.getFirstCoordinate(), content);
 });
-select.getFeatures().on('remove', function(e) {
+select.getFeatures().on('remove', function (e) {
     popup.hide();
 })
 

--- a/examples/style/map.style.font.ts
+++ b/examples/style/map.style.font.ts
@@ -46,9 +46,9 @@ function setText(t: string) {
     vector.changed();
 }
 // Fill font glyphs
-const glyph = FontSymbol.prototype.defs.glyphs;
+const glyph = FontSymbol.defs.glyphs;
 const opt: HTMLDivElement = document.querySelector<HTMLDivElement>(".options")!;
-for (const font in FontSymbol.prototype.defs.fonts) {
+for (const font in FontSymbol.defs.fonts) {
     const h2 = document.createElement("h2");
     h2.textContent = font+":";
     opt.appendChild(h2);

--- a/examples/style/map.style.pattern.ts
+++ b/examples/style/map.style.pattern.ts
@@ -9,6 +9,13 @@ import { Polygon } from 'ol/geom';
 let refresh: any;
 const imgFile = '../data/pattern.png';
 
+declare global {
+  interface Window {
+    $(selector: any, context?: any): any,
+    refresh(): void
+  }
+}
+
 $(window).on('load', () => {
        FillPattern.addPattern("copy (char pattern)", { char: "©" });
        FillPattern.addPattern("bug (fontawesome)", { char: '\uf188', size: 12, font: "10px FontAwesome" });
@@ -21,7 +28,7 @@ $(window).on('load', () => {
 
         let pat = "hatch";
         const spattern = $("#pselect");
-        for (const i in FillPattern.prototype.patterns) {
+        for (const i in FillPattern.patterns) {
             const p = new FillPattern({ pattern: i });
             $("<div>").attr('title', i)
                 .css("background-image", 'url("' + p.getImage().toDataURL() + '")')
@@ -66,6 +73,9 @@ $(window).on('load', () => {
                 });
             $("#select").css('background-image', 'url(' + p.getImage().toDataURL() + ')');
         };
+        window.refresh = (): void => {
+            refresh();
+        }
 
         // Layers
         const layer = new Tile({
@@ -99,7 +109,7 @@ $(window).on('load', () => {
                             image: (p == 'Image (PNG)') ? new Icon({ src: imgFile }) : undefined,
                             ratio: 1,
                             icon: p == 'Image (PNG)' ? new Icon({ src: 'data/target.png' }) : undefined,
-                            color: $("#color").text(),
+                            color: $("#color").val()?.toString(),
                             offset: Number($("#offset").val()),
                             scale: Number($("#scale").val()),
                             fill: new Fill({ color: $("#bg").val()?.toString() }),

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -23,7 +23,7 @@
     "strictNullChecks": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "target": "es5",
+    "target": "ES6",
     "rootDir": "./",
     "outDir": "../ol-ext/examples"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,12 +21,12 @@
         "exports-loader": "^3.1.0",
         "fs-extra": "^10.1.0",
         "jsdoc": "^3.6.11",
-        "node-html-parser": "^5.4.1",
-        "ol": "^6.15.1",
-        "ol-ext": "^3.2.30",
+        "node-html-parser": "^5.4.2",
+        "ol": "^7.1.0",
+        "ol-ext": "^4.0.0",
         "ts-loader": "^9.3.1",
-        "tsd": "^0.21.0",
-        "typescript": "^4.8.2",
+        "tsd": "^0.24.1",
+        "typescript": "^4.8.3",
         "webpack": "^5.74.0",
         "webpack-cli": "^4.10.0"
       }
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.18.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.13.tgz",
-      "integrity": "sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
+      "integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -150,9 +150,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
+      "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -314,14 +314,14 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
+      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.2",
+        "espree": "^9.4.0",
         "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -331,6 +331,9 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
@@ -364,6 +367,19 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
       "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
       "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
@@ -555,14 +571,10 @@
       }
     },
     "node_modules/@tsd/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-jbtC+RgKZ9Kk65zuRZbKLTACf+tvFW4Rfq0JEMXrlmV3P3yme+Hm+pnb5fJRyt61SjIitcrC810wj7+1tgsEmg==",
-      "dev": true,
-      "bin": {
-        "tsc": "typescript/bin/tsc",
-        "tsserver": "typescript/bin/tsserver"
-      }
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-ytRZWmXF0i4VFSG8NQ67NUDQ3NGe3E4oByFrxH8eJyW5uBOM5juIdXCg81OY/IcK81qHCzrvGEo8tujlIQbexw==",
+      "dev": true
     },
     "node_modules/@types/eslint": {
       "version": "7.29.0",
@@ -653,9 +665,9 @@
       "dev": true
     },
     "node_modules/@types/minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-0RJHq5FqDWo17kdHe+SMDJLfxmLaqHbWnqZ6gNKzDvStUlrmx/eKIY17+ifLS1yybo7X86aUshQMlittDOVNnw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
     "node_modules/@types/minimist": {
@@ -665,9 +677,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.26.tgz",
-      "integrity": "sha512-0b+utRBSYj8L7XAp0d+DX7lI4cSmowNaaTkk6/1SKzbKkG+doLuPusB9EOvzLJ8ahJSk03bTLIL6cWaEd4dBKA==",
+      "version": "14.18.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.29.tgz",
+      "integrity": "sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -706,14 +718,14 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.35.1.tgz",
-      "integrity": "sha512-RBZZXZlI4XCY4Wzgy64vB+0slT9+yAPQRjj/HSaRwUot33xbDjF1oN9BLwOLTewoOI0jothIltZRe9uJCHf8gg==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.37.0.tgz",
+      "integrity": "sha512-Fde6W0IafXktz1UlnhGkrrmnnGpAo1kyX7dnyHHVrmwJOn72Oqm3eYtddrpOwwel2W8PAK9F3pIL5S+lfoM0og==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.35.1",
-        "@typescript-eslint/type-utils": "5.35.1",
-        "@typescript-eslint/utils": "5.35.1",
+        "@typescript-eslint/scope-manager": "5.37.0",
+        "@typescript-eslint/type-utils": "5.37.0",
+        "@typescript-eslint/utils": "5.37.0",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -754,14 +766,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.35.1.tgz",
-      "integrity": "sha512-XL2TBTSrh3yWAsMYpKseBYTVpvudNf69rPOWXWVBI08My2JVT5jR66eTt4IgQFHA/giiKJW5dUD4x/ZviCKyGg==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.37.0.tgz",
+      "integrity": "sha512-01VzI/ipYKuaG5PkE5+qyJ6m02fVALmMPY3Qq5BHflDx3y4VobbLdHQkSMg9VPRS4KdNt4oYTMaomFoHonBGAw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.35.1",
-        "@typescript-eslint/types": "5.35.1",
-        "@typescript-eslint/typescript-estree": "5.35.1",
+        "@typescript-eslint/scope-manager": "5.37.0",
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/typescript-estree": "5.37.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -781,13 +793,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.35.1.tgz",
-      "integrity": "sha512-kCYRSAzIW9ByEIzmzGHE50NGAvAP3wFTaZevgWva7GpquDyFPFcmvVkFJGWJJktg/hLwmys/FZwqM9EKr2u24Q==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
+      "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.35.1",
-        "@typescript-eslint/visitor-keys": "5.35.1"
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/visitor-keys": "5.37.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -798,12 +810,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.35.1.tgz",
-      "integrity": "sha512-8xT8ljvo43Mp7BiTn1vxLXkjpw8wS4oAc00hMSB4L1/jIiYbjjnc3Qp2GAUOG/v8zsNCd1qwcqfCQ0BuishHkw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.37.0.tgz",
+      "integrity": "sha512-BSx/O0Z0SXOF5tY0bNTBcDEKz2Ec20GVYvq/H/XNKiUorUFilH7NPbFUuiiyzWaSdN3PA8JV0OvYx0gH/5aFAQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.35.1",
+        "@typescript-eslint/typescript-estree": "5.37.0",
+        "@typescript-eslint/utils": "5.37.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -824,9 +837,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.35.1.tgz",
-      "integrity": "sha512-FDaujtsH07VHzG0gQ6NDkVVhi1+rhq0qEvzHdJAQjysN+LHDCKDKCBRlZFFE0ec0jKxiv0hN63SNfExy0KrbQQ==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
+      "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -837,13 +850,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.35.1.tgz",
-      "integrity": "sha512-JUqE1+VRTGyoXlDWWjm6MdfpBYVq+hixytrv1oyjYIBEOZhBCwtpp5ZSvBt4wIA1MKWlnaC2UXl2XmYGC3BoQA==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
+      "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.35.1",
-        "@typescript-eslint/visitor-keys": "5.35.1",
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/visitor-keys": "5.37.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -879,15 +892,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.35.1.tgz",
-      "integrity": "sha512-v6F8JNXgeBWI4pzZn36hT2HXXzoBBBJuOYvoQiaQaEEjdi5STzux3Yj8v7ODIpx36i/5s8TdzuQ54TPc5AITQQ==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.37.0.tgz",
+      "integrity": "sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.35.1",
-        "@typescript-eslint/types": "5.35.1",
-        "@typescript-eslint/typescript-estree": "5.35.1",
+        "@typescript-eslint/scope-manager": "5.37.0",
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/typescript-estree": "5.37.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -903,12 +916,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.35.1.tgz",
-      "integrity": "sha512-cEB1DvBVo1bxbW/S5axbGPE6b7FIMAbo3w+AGq6zNDA7+NYJOIkKj/sInfTv4edxd4PxJSgdN4t6/pbvgA+n5g==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
+      "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/types": "5.37.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1515,9 +1528,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "dev": true,
       "funding": [
         {
@@ -1530,10 +1543,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001370",
-        "electron-to-chromium": "^1.4.202",
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.5"
+        "update-browserslist-db": "^1.0.9"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1634,9 +1647,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001383",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001383.tgz",
-      "integrity": "sha512-swMpEoTp5vDoGBZsYZX7L7nXHe6dsHxi9o6/LKf/f0LukVtnrxly5GVb/fWdCDTqi/yw6Km6tiJ0pmBacm0gbg==",
+      "version": "1.0.30001402",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001402.tgz",
+      "integrity": "sha512-Mx4MlhXO5NwuvXGgVb+hg65HZ+bhUYsz8QtDGDo2QmaJS2GBX47Xfi2koL86lc8K+l+htXeTEB/Aeqvezoo6Ew==",
       "dev": true,
       "funding": [
         {
@@ -1864,9 +1877,9 @@
       "optional": true
     },
     "node_modules/core-js": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.0.tgz",
-      "integrity": "sha512-CVU1xvJEfJGhyCpBrzzzU1kjCfgsGUxhEvwUV2e/cOedYWHdmluamx+knDnmhqALddMG16fZvIqvs9aijsHHaA==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.1.tgz",
+      "integrity": "sha512-sr0FY4lnO1hkQ4gLDr24K0DGnweGO1QwSj5BpfQjpSJPdqWalja4cTps29Y/PJVG/P7FYlPDkH3hO+Tr0CvDgQ==",
       "hasInstallScript": true,
       "optional": true,
       "funding": {
@@ -2113,6 +2126,12 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "dev": true
+    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -2124,9 +2143,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.232",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.232.tgz",
-      "integrity": "sha512-nd+FW8xHjM+PxNWG44nKnwHaBDdVpJUZuI2sS2JJPt/QpdombnmoCRWEEQNnzaktdIQhsNWdD+dlqxwO8Bn99g==",
+      "version": "1.4.254",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
+      "integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -2215,14 +2234,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.22.0.tgz",
-      "integrity": "sha512-ci4t0sz6vSRKdmkOGmprBo6fmI4PrphDFMy5JEq/fNS0gQkJM3rLmrqcp8ipMcdobH3KtUP40KniAE9W19S4wA==",
+      "version": "8.23.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
+      "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.3.0",
+        "@eslint/eslintrc": "^1.3.2",
         "@humanwhocodes/config-array": "^0.10.4",
         "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+        "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -2232,13 +2252,12 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.3",
+        "espree": "^9.4.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
         "globby": "^11.1.0",
@@ -2247,6 +2266,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -2257,8 +2277,7 @@
         "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "text-table": "^0.2.0"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -2405,9 +2424,9 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
-      "integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
+      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
@@ -2544,9 +2563,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3330,6 +3349,12 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-sdsl": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
+      "integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==",
+      "dev": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3674,9 +3699,9 @@
       }
     },
     "node_modules/markdown-it-anchor": {
-      "version": "8.6.4",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.4.tgz",
-      "integrity": "sha512-Ul4YVYZNxMJYALpKtu+ZRdrryYt/GlQ5CK+4l1bp/gWXOG2QWElt6AqF3Mih/wfUKdZbNAZVXGR73/n6U/8img==",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.5.tgz",
+      "integrity": "sha512-PI1qEHHkTNWT+X6Ip9w+paonfIQ+QZP9sCeMYi47oqhH+EsW8CrJ8J7CzV19QVOj6il8ATGbK2nTECj22ZHGvQ==",
       "dev": true,
       "peerDependencies": {
         "@types/markdown-it": "*",
@@ -3684,9 +3709,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.19.tgz",
-      "integrity": "sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+      "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -3885,9 +3910,9 @@
       "dev": true
     },
     "node_modules/node-html-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-5.4.1.tgz",
-      "integrity": "sha512-xy/O2wOEBJsIRLs4avwa1lVY7tIpXXOoHHUJLa0GvnoPPqMG1hgBVl1tNI3GHOwRktTVZy+Y6rjghk4B9/NLyg==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-5.4.2.tgz",
+      "integrity": "sha512-RaBPP3+51hPne/OolXxcz89iYvQvKOydaqoePpOgXcrOKZhjVIzmpKZz+Hd/RBO2/zN2q6CNJhQzucVz+u3Jyw==",
       "dev": true,
       "dependencies": {
         "css-select": "^4.2.1",
@@ -4014,13 +4039,14 @@
       }
     },
     "node_modules/ol": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.15.1.tgz",
-      "integrity": "sha512-ZG2CKTpJ8Q+tPywYysVwPk+yevwJzlbwjRKhoCvd7kLVWMbfBl1O/+Kg/yrZZrhG9FNXbFH4GeOZ5yVRqo3P4w==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-7.1.0.tgz",
+      "integrity": "sha512-mAeV5Ca4mFhYaJoGWNZnIMN5VNnFTf63FgZjBiYu/DjQDGKNsD5QyvvqVziioVdOOgl6b8rPB/ypj2XNBinPwA==",
       "dev": true,
       "dependencies": {
+        "earcut": "^2.2.3",
         "geotiff": "2.0.4",
-        "ol-mapbox-style": "^8.0.5",
+        "ol-mapbox-style": "9.1.0",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       },
@@ -4030,18 +4056,18 @@
       }
     },
     "node_modules/ol-ext": {
-      "version": "3.2.30",
-      "resolved": "https://registry.npmjs.org/ol-ext/-/ol-ext-3.2.30.tgz",
-      "integrity": "sha512-2Ls6FxfSRHzn7RzBAdeooiwcgA+dfR5a7it9xKLMgzIdVJhqSC1IyVSnPMmaX8yoLFEwywQHEzTQXlfGzUoEOw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ol-ext/-/ol-ext-4.0.0.tgz",
+      "integrity": "sha512-FVP66Hzcmd2/uXuVnINSErON1aUu2fRtj1AdEl6mLFjQF0ij4ZHWAFq39Fat6Uhc6+JFn0fc4v3tZAAsZsdxtA==",
       "dev": true,
       "peerDependencies": {
         "ol": ">= 5.3.0"
       }
     },
     "node_modules/ol-mapbox-style": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-8.2.1.tgz",
-      "integrity": "sha512-3kBBuZC627vDL8vnUdfVbCbfkhkcZj2kXPHQcuLhC4JJEA+XkEVEtEde8x8+AZctRbHwBkSiubTPaRukgLxIRw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-9.1.0.tgz",
+      "integrity": "sha512-R/XE6FdviaXNdnSw6ItHSEreMtQU68cwQCGv4Kl8yG0V1dZhnI5JWr8IOphJwffPVxfWTCnJb5aALGSB89MvhA==",
       "dev": true,
       "dependencies": {
         "@mapbox/mapbox-gl-style-spec": "^13.23.1",
@@ -5149,9 +5175,9 @@
       }
     },
     "node_modules/supports-hyperlinks": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
-      "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0",
@@ -5261,9 +5287,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.5.tgz",
-      "integrity": "sha512-AOEDLDxD2zylUGf/wxHxklEkOe2/r+seuyOWujejFrIxHf11brA1/dWQNIgXa1c6/Wkxgu7zvv0JhOWfc2ELEA==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+      "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.14",
@@ -5390,12 +5416,12 @@
       }
     },
     "node_modules/tsd": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.21.0.tgz",
-      "integrity": "sha512-6DugCw1Q4H8HYwDT3itzgALjeDxN4RO3iqu7gRdC/YNVSCRSGXRGQRRasftL1uKDuKxlFffYKHv5j5G7YnKGxQ==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.24.1.tgz",
+      "integrity": "sha512-sD+s81/2aM4RRhimCDttd4xpBNbUFWnoMSHk/o8kC8Ek23jljeRNWjsxFJmOmYLuLTN9swRt1b6iXfUXTcTiIA==",
       "dev": true,
       "dependencies": {
-        "@tsd/typescript": "~4.7.3",
+        "@tsd/typescript": "~4.8.3",
         "eslint-formatter-pretty": "^4.1.0",
         "globby": "^11.0.1",
         "meow": "^9.0.0",
@@ -5406,7 +5432,7 @@
         "tsd": "dist/cli.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.16"
       }
     },
     "node_modules/tslib": {
@@ -5623,9 +5649,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5657,9 +5683,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
-      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
+      "integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
       "dev": true,
       "funding": [
         {
@@ -5715,12 +5741,6 @@
       "bin": {
         "uuid": "bin/uuid"
       }
-    },
-    "node_modules/v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-      "dev": true
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -6161,9 +6181,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "dev": true
     },
     "@babel/highlight": {
@@ -6236,15 +6256,15 @@
       }
     },
     "@babel/parser": {
-      "version": "7.18.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.13.tgz",
-      "integrity": "sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
+      "integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==",
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
+      "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -6380,14 +6400,14 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
+      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.2",
+        "espree": "^9.4.0",
         "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -6419,6 +6439,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
       "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
+      "dev": true
+    },
+    "@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true
     },
     "@humanwhocodes/object-schema": {
@@ -6574,9 +6600,9 @@
       }
     },
     "@tsd/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-jbtC+RgKZ9Kk65zuRZbKLTACf+tvFW4Rfq0JEMXrlmV3P3yme+Hm+pnb5fJRyt61SjIitcrC810wj7+1tgsEmg==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-ytRZWmXF0i4VFSG8NQ67NUDQ3NGe3E4oByFrxH8eJyW5uBOM5juIdXCg81OY/IcK81qHCzrvGEo8tujlIQbexw==",
       "dev": true
     },
     "@types/eslint": {
@@ -6668,9 +6694,9 @@
       "dev": true
     },
     "@types/minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-0RJHq5FqDWo17kdHe+SMDJLfxmLaqHbWnqZ6gNKzDvStUlrmx/eKIY17+ifLS1yybo7X86aUshQMlittDOVNnw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
     "@types/minimist": {
@@ -6680,9 +6706,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.26.tgz",
-      "integrity": "sha512-0b+utRBSYj8L7XAp0d+DX7lI4cSmowNaaTkk6/1SKzbKkG+doLuPusB9EOvzLJ8ahJSk03bTLIL6cWaEd4dBKA==",
+      "version": "14.18.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.29.tgz",
+      "integrity": "sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -6721,14 +6747,14 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.35.1.tgz",
-      "integrity": "sha512-RBZZXZlI4XCY4Wzgy64vB+0slT9+yAPQRjj/HSaRwUot33xbDjF1oN9BLwOLTewoOI0jothIltZRe9uJCHf8gg==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.37.0.tgz",
+      "integrity": "sha512-Fde6W0IafXktz1UlnhGkrrmnnGpAo1kyX7dnyHHVrmwJOn72Oqm3eYtddrpOwwel2W8PAK9F3pIL5S+lfoM0og==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.35.1",
-        "@typescript-eslint/type-utils": "5.35.1",
-        "@typescript-eslint/utils": "5.35.1",
+        "@typescript-eslint/scope-manager": "5.37.0",
+        "@typescript-eslint/type-utils": "5.37.0",
+        "@typescript-eslint/utils": "5.37.0",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -6749,52 +6775,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.35.1.tgz",
-      "integrity": "sha512-XL2TBTSrh3yWAsMYpKseBYTVpvudNf69rPOWXWVBI08My2JVT5jR66eTt4IgQFHA/giiKJW5dUD4x/ZviCKyGg==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.37.0.tgz",
+      "integrity": "sha512-01VzI/ipYKuaG5PkE5+qyJ6m02fVALmMPY3Qq5BHflDx3y4VobbLdHQkSMg9VPRS4KdNt4oYTMaomFoHonBGAw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.35.1",
-        "@typescript-eslint/types": "5.35.1",
-        "@typescript-eslint/typescript-estree": "5.35.1",
+        "@typescript-eslint/scope-manager": "5.37.0",
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/typescript-estree": "5.37.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.35.1.tgz",
-      "integrity": "sha512-kCYRSAzIW9ByEIzmzGHE50NGAvAP3wFTaZevgWva7GpquDyFPFcmvVkFJGWJJktg/hLwmys/FZwqM9EKr2u24Q==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
+      "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.35.1",
-        "@typescript-eslint/visitor-keys": "5.35.1"
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/visitor-keys": "5.37.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.35.1.tgz",
-      "integrity": "sha512-8xT8ljvo43Mp7BiTn1vxLXkjpw8wS4oAc00hMSB4L1/jIiYbjjnc3Qp2GAUOG/v8zsNCd1qwcqfCQ0BuishHkw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.37.0.tgz",
+      "integrity": "sha512-BSx/O0Z0SXOF5tY0bNTBcDEKz2Ec20GVYvq/H/XNKiUorUFilH7NPbFUuiiyzWaSdN3PA8JV0OvYx0gH/5aFAQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.35.1",
+        "@typescript-eslint/typescript-estree": "5.37.0",
+        "@typescript-eslint/utils": "5.37.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.35.1.tgz",
-      "integrity": "sha512-FDaujtsH07VHzG0gQ6NDkVVhi1+rhq0qEvzHdJAQjysN+LHDCKDKCBRlZFFE0ec0jKxiv0hN63SNfExy0KrbQQ==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
+      "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.35.1.tgz",
-      "integrity": "sha512-JUqE1+VRTGyoXlDWWjm6MdfpBYVq+hixytrv1oyjYIBEOZhBCwtpp5ZSvBt4wIA1MKWlnaC2UXl2XmYGC3BoQA==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
+      "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.35.1",
-        "@typescript-eslint/visitor-keys": "5.35.1",
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/visitor-keys": "5.37.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -6814,26 +6841,26 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.35.1.tgz",
-      "integrity": "sha512-v6F8JNXgeBWI4pzZn36hT2HXXzoBBBJuOYvoQiaQaEEjdi5STzux3Yj8v7ODIpx36i/5s8TdzuQ54TPc5AITQQ==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.37.0.tgz",
+      "integrity": "sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.35.1",
-        "@typescript-eslint/types": "5.35.1",
-        "@typescript-eslint/typescript-estree": "5.35.1",
+        "@typescript-eslint/scope-manager": "5.37.0",
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/typescript-estree": "5.37.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.35.1.tgz",
-      "integrity": "sha512-cEB1DvBVo1bxbW/S5axbGPE6b7FIMAbo3w+AGq6zNDA7+NYJOIkKj/sInfTv4edxd4PxJSgdN4t6/pbvgA+n5g==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
+      "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/types": "5.37.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -7333,15 +7360,15 @@
       }
     },
     "browserslist": {
-      "version": "4.21.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001370",
-        "electron-to-chromium": "^1.4.202",
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.5"
+        "update-browserslist-db": "^1.0.9"
       }
     },
     "btoa": {
@@ -7401,9 +7428,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001383",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001383.tgz",
-      "integrity": "sha512-swMpEoTp5vDoGBZsYZX7L7nXHe6dsHxi9o6/LKf/f0LukVtnrxly5GVb/fWdCDTqi/yw6Km6tiJ0pmBacm0gbg==",
+      "version": "1.0.30001402",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001402.tgz",
+      "integrity": "sha512-Mx4MlhXO5NwuvXGgVb+hg65HZ+bhUYsz8QtDGDo2QmaJS2GBX47Xfi2koL86lc8K+l+htXeTEB/Aeqvezoo6Ew==",
       "dev": true
     },
     "canvg": {
@@ -7584,9 +7611,9 @@
       "optional": true
     },
     "core-js": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.0.tgz",
-      "integrity": "sha512-CVU1xvJEfJGhyCpBrzzzU1kjCfgsGUxhEvwUV2e/cOedYWHdmluamx+knDnmhqALddMG16fZvIqvs9aijsHHaA==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.1.tgz",
+      "integrity": "sha512-sr0FY4lnO1hkQ4gLDr24K0DGnweGO1QwSj5BpfQjpSJPdqWalja4cTps29Y/PJVG/P7FYlPDkH3hO+Tr0CvDgQ==",
       "optional": true
     },
     "core-util-is": {
@@ -7768,6 +7795,12 @@
         "domhandler": "^4.2.0"
       }
     },
+    "earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -7779,9 +7812,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.232",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.232.tgz",
-      "integrity": "sha512-nd+FW8xHjM+PxNWG44nKnwHaBDdVpJUZuI2sS2JJPt/QpdombnmoCRWEEQNnzaktdIQhsNWdD+dlqxwO8Bn99g==",
+      "version": "1.4.254",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
+      "integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q==",
       "dev": true
     },
     "emoji-regex": {
@@ -7849,14 +7882,15 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.22.0.tgz",
-      "integrity": "sha512-ci4t0sz6vSRKdmkOGmprBo6fmI4PrphDFMy5JEq/fNS0gQkJM3rLmrqcp8ipMcdobH3KtUP40KniAE9W19S4wA==",
+      "version": "8.23.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
+      "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.3.0",
+        "@eslint/eslintrc": "^1.3.2",
         "@humanwhocodes/config-array": "^0.10.4",
         "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+        "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -7866,13 +7900,12 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.3",
+        "espree": "^9.4.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
         "globby": "^11.1.0",
@@ -7881,6 +7914,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -7891,8 +7925,7 @@
         "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "text-table": "^0.2.0"
       },
       "dependencies": {
         "eslint-scope": {
@@ -7994,9 +8027,9 @@
       "dev": true
     },
     "espree": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
-      "integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
+      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.0",
@@ -8090,9 +8123,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -8692,6 +8725,12 @@
         }
       }
     },
+    "js-sdsl": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
+      "integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8971,16 +9010,16 @@
       }
     },
     "markdown-it-anchor": {
-      "version": "8.6.4",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.4.tgz",
-      "integrity": "sha512-Ul4YVYZNxMJYALpKtu+ZRdrryYt/GlQ5CK+4l1bp/gWXOG2QWElt6AqF3Mih/wfUKdZbNAZVXGR73/n6U/8img==",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.5.tgz",
+      "integrity": "sha512-PI1qEHHkTNWT+X6Ip9w+paonfIQ+QZP9sCeMYi47oqhH+EsW8CrJ8J7CzV19QVOj6il8ATGbK2nTECj22ZHGvQ==",
       "dev": true,
       "requires": {}
     },
     "marked": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.19.tgz",
-      "integrity": "sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+      "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
       "dev": true
     },
     "mdurl": {
@@ -9133,9 +9172,9 @@
       "dev": true
     },
     "node-html-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-5.4.1.tgz",
-      "integrity": "sha512-xy/O2wOEBJsIRLs4avwa1lVY7tIpXXOoHHUJLa0GvnoPPqMG1hgBVl1tNI3GHOwRktTVZy+Y6rjghk4B9/NLyg==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-5.4.2.tgz",
+      "integrity": "sha512-RaBPP3+51hPne/OolXxcz89iYvQvKOydaqoePpOgXcrOKZhjVIzmpKZz+Hd/RBO2/zN2q6CNJhQzucVz+u3Jyw==",
       "dev": true,
       "requires": {
         "css-select": "^4.2.1",
@@ -9236,28 +9275,29 @@
       "optional": true
     },
     "ol": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.15.1.tgz",
-      "integrity": "sha512-ZG2CKTpJ8Q+tPywYysVwPk+yevwJzlbwjRKhoCvd7kLVWMbfBl1O/+Kg/yrZZrhG9FNXbFH4GeOZ5yVRqo3P4w==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-7.1.0.tgz",
+      "integrity": "sha512-mAeV5Ca4mFhYaJoGWNZnIMN5VNnFTf63FgZjBiYu/DjQDGKNsD5QyvvqVziioVdOOgl6b8rPB/ypj2XNBinPwA==",
       "dev": true,
       "requires": {
+        "earcut": "^2.2.3",
         "geotiff": "2.0.4",
-        "ol-mapbox-style": "^8.0.5",
+        "ol-mapbox-style": "9.1.0",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       }
     },
     "ol-ext": {
-      "version": "3.2.30",
-      "resolved": "https://registry.npmjs.org/ol-ext/-/ol-ext-3.2.30.tgz",
-      "integrity": "sha512-2Ls6FxfSRHzn7RzBAdeooiwcgA+dfR5a7it9xKLMgzIdVJhqSC1IyVSnPMmaX8yoLFEwywQHEzTQXlfGzUoEOw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ol-ext/-/ol-ext-4.0.0.tgz",
+      "integrity": "sha512-FVP66Hzcmd2/uXuVnINSErON1aUu2fRtj1AdEl6mLFjQF0ij4ZHWAFq39Fat6Uhc6+JFn0fc4v3tZAAsZsdxtA==",
       "dev": true,
       "requires": {}
     },
     "ol-mapbox-style": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-8.2.1.tgz",
-      "integrity": "sha512-3kBBuZC627vDL8vnUdfVbCbfkhkcZj2kXPHQcuLhC4JJEA+XkEVEtEde8x8+AZctRbHwBkSiubTPaRukgLxIRw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-9.1.0.tgz",
+      "integrity": "sha512-R/XE6FdviaXNdnSw6ItHSEreMtQU68cwQCGv4Kl8yG0V1dZhnI5JWr8IOphJwffPVxfWTCnJb5aALGSB89MvhA==",
       "dev": true,
       "requires": {
         "@mapbox/mapbox-gl-style-spec": "^13.23.1",
@@ -10091,9 +10131,9 @@
       }
     },
     "supports-hyperlinks": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
-      "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
       "dev": true,
       "requires": {
         "has-flag": "^4.0.0",
@@ -10172,9 +10212,9 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.5.tgz",
-      "integrity": "sha512-AOEDLDxD2zylUGf/wxHxklEkOe2/r+seuyOWujejFrIxHf11brA1/dWQNIgXa1c6/Wkxgu7zvv0JhOWfc2ELEA==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+      "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.14",
@@ -10257,12 +10297,12 @@
       }
     },
     "tsd": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.21.0.tgz",
-      "integrity": "sha512-6DugCw1Q4H8HYwDT3itzgALjeDxN4RO3iqu7gRdC/YNVSCRSGXRGQRRasftL1uKDuKxlFffYKHv5j5G7YnKGxQ==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.24.1.tgz",
+      "integrity": "sha512-sD+s81/2aM4RRhimCDttd4xpBNbUFWnoMSHk/o8kC8Ek23jljeRNWjsxFJmOmYLuLTN9swRt1b6iXfUXTcTiIA==",
       "dev": true,
       "requires": {
-        "@tsd/typescript": "~4.7.3",
+        "@tsd/typescript": "~4.8.3",
         "eslint-formatter-pretty": "^4.1.0",
         "globby": "^11.0.1",
         "meow": "^9.0.0",
@@ -10435,9 +10475,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true
     },
     "uc.micro": {
@@ -10459,9 +10499,9 @@
       "dev": true
     },
     "update-browserslist-db": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
-      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
+      "integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
       "dev": true,
       "requires": {
         "escalade": "^3.1.1",
@@ -10496,12 +10536,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
-    },
-    "v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
     "validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
     "exports-loader": "^3.1.0",
     "fs-extra": "^10.1.0",
     "jsdoc": "^3.6.11",
-    "node-html-parser": "^5.4.1",
-    "ol": "^6.15.1",
-    "ol-ext": "^3.2.30",
+    "node-html-parser": "^5.4.2",
+    "ol": "^7.1.0",
+    "ol-ext": "^4.0.0",
     "ts-loader": "^9.3.1",
-    "tsd": "^0.21.0",
-    "typescript": "^4.8.2",
+    "tsd": "^0.24.1",
+    "typescript": "^4.8.3",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "resolveJsonModule": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "target": "ES2017",


### PR DESCRIPTION
I could not get the examples to work yet:

```
Uncaught TypeError: ol.ext is undefined
    js Base.js:10
    Webpack 11
[Base.js:10](webpack://siedlerchr/types-ol-ext/node_modules/ol-ext/util/input/Base.js)
    js Base.js:10
    Webpack 11
```

@sanak  Any idea if we need to change sth here or if ol-ext needs to change it?


