### PR TITLE
Fix types for swipe & swipe-map control

### DIFF
--- a/@types/ol-ext/control/Swipe.d.ts
+++ b/@types/ol-ext/control/Swipe.d.ts
@@ -4,11 +4,11 @@ import { Layer } from "ol/layer";
 import { Extent } from "ol/extent";
 
 export interface Options extends ControlOptions {
-  layers?: Layer;
-  rightLayers?: Layer;
+  layers?: Layer | Layer[];
+  rightLayers?: Layer | Layer[];
   className?: string;
   position?: number;
-  orientation?: "vertical" | "horizontal;";
+  orientation?: "vertical" | "horizontal";
 }
 
 /**
@@ -17,11 +17,11 @@ export interface Options extends ControlOptions {
  * @constructor
  * @extends {ol_control_Control}
  * @param {Object=} Control options.
- *  @param {ol.layer} options.layers layer to swipe
- *  @param {ol.layer} options.rightLayer layer to swipe on right side
+ *  @param {ol.layer|Array<ol.layer>} options.layers layers to swipe
+ *  @param {ol.layer|Array<ol.layer>} options.rightLayers layers to swipe on right side
  *  @param {string} options.className control class name
- *  @param {number} options.position position propertie of the swipe [0,1], default 0.5
- *  @param {string} options.orientation orientation propertie (vertical|horizontal), default vertical
+ *  @param {number} options.position position property of the swipe [0,1], default 0.5
+ *  @param {string} options.orientation orientation property (vertical|horizontal), default vertical
  */
 export default class Swipe extends ol_control_Control {
   constructor(options?: Options);

--- a/@types/ol-ext/control/SwipeMap.d.ts
+++ b/@types/ol-ext/control/SwipeMap.d.ts
@@ -1,14 +1,12 @@
 import { Map as _ol_Map_ } from "ol";
 import { Extent } from 'ol/extent';
 import ol_control_Control, { Options as ControlOptions } from "ol/control/Control";
-import { Layer } from "ol/layer";
 
 export interface Options extends ControlOptions{
-    layer?: Layer;
-    rightLayer?: Layer;
     className?: string;
     position?: number[],
-    orientaton?: 'vertical'| 'horizontal'
+    orientation?: 'vertical'| 'horizontal',
+    right?: boolean;
 }
 
 /** A control that use a CSS clip rect to swipe the map
@@ -17,11 +15,10 @@ export interface Options extends ControlOptions{
  * @constructor
  * @extends {ol_control_Control}
  * @param {Object=} Control options.
- *  @param {ol.layer} options.layers layer to swipe
- *  @param {ol.layer} options.rightLayer layer to swipe on right side
  *  @param {string} options.className control class name
- *  @param {number} options.position position propertie of the swipe [0,1], default 0.5
- *  @param {string} options.orientation orientation propertie (vertical|horizontal), default vertical
+ *  @param {number} options.position position property of the swipe [0,1], default 0.5
+ *  @param {string} options.orientation orientation property (vertical|horizontal), default vertical
+ *  @param {boolean} options.right true to position map on right side (resp. bottom for horizontal orientation), default false
  */
 export default class SwipeMap extends ol_control_Control {
     constructor(options: any);


### PR DESCRIPTION
Hi, some small changes to the types of both swipe controls:

1. A typo in the definition for `options.orientation` led to type errors when using the constructor options.
2. Both the swipe & swipe map control were missing some options, e.g. using an array of layers besides a single layer. It was already missing in the original JSDoc comments in ol-ext, so I opened a PR over there: https://github.com/Viglino/ol-ext/pull/879.

This PR is ready as soon as the upstream PR is merged.