### PR TITLE
Several minor corrections on LayerSwitcher, Legend, and LegendItem

### DIFF
--- a/@types/ol-ext/control/LayerSwitcher.d.ts
+++ b/@types/ol-ext/control/LayerSwitcher.d.ts
@@ -39,7 +39,7 @@ export interface Options extends ControlOptions {
   reordering?: boolean;
   trash?: boolean;
   oninfo?: (l: Layer) => void;
-  extent?: Extent;
+  extent?: boolean;
   onExtent?: (l: Layer) => void;
   drawDelay?: number;
   collapsed?: boolean;

--- a/@types/ol-ext/legend/Item.d.ts
+++ b/@types/ol-ext/legend/Item.d.ts
@@ -1,3 +1,4 @@
+import type BaseObject from 'ol/Object';
 import type Feature from 'ol/Feature'
 import type { StyleLike } from 'ol/style/Style'
 import type { Size } from 'ol/size'
@@ -62,7 +63,7 @@ export type olLegendItemOptions = {
  * @constructor
  * @fires select
  */
-export default class LegendItem {
+export default class LegendItem extends BaseObject {
   /**
    * @param {olLegendItemOptions} options
    */

--- a/@types/ol-ext/legend/Item.d.ts
+++ b/@types/ol-ext/legend/Item.d.ts
@@ -11,7 +11,7 @@ export type olLegendItemOptions = {
    * row title
    */
   title: string;
-  className: string;
+  className?: string;
   /**
    * a feature to draw on the legend
    */
@@ -25,10 +25,21 @@ export type olLegendItemOptions = {
    */
   properties?: any;
   /**
-   * a style or a style function to use to draw the legend
+   * a style or a style function to use to draw the legend symbol
    */
-  style: StyleLike;
-  textStyle: Text
+  style?: StyleLike;
+  /**
+   * a text style to draw the item title in the legend
+   */
+  textStyle?: Text;
+  /**
+   * the symbol width, default use the default width
+   */
+  width?: number;
+  /**
+   * the symbol height, default use the default height
+   */
+  height?: number;
   size?: Size
   margin?: number
 };
@@ -41,6 +52,8 @@ export type olLegendItemOptions = {
  *  @property {Object} properties a set of properties to use with a style function
  *  @property {StyleLike} style a style or a style function to use to draw the legend symbol
  *  @property {Text} textStyle a text style to draw the item title in the legend
+ *  @property {number|undefined} width the symbol width, default use the default width
+ *  @property {number|undefined} height the symbol height, default use the default height
  *  @property {Size|undefined} size
  *  @property {number|undefined} margin
  */

--- a/@types/ol-ext/legend/Legend.d.ts
+++ b/@types/ol-ext/legend/Legend.d.ts
@@ -5,6 +5,7 @@ import type { Size } from 'ol/size'
 import type Layer from 'ol/layer/Layer'
 import type ol_legend_Item from './Item'
 import type { olLegendItemOptions } from './Item'
+import type BaseObject from 'ol/Object';
 
 export interface Options {
   title?: string;
@@ -22,7 +23,7 @@ export interface Options {
  * @fires select
  * @fires refresh
  */
-export default class ol_legend_Legend {
+export default class ol_legend_Legend extends BaseObject {
   /** Get a symbol image for a given legend item
    * @param {olLegendItemOptions} item
    * @param {Canvas|undefined} canvas a canvas to draw in, if none creat one
@@ -124,4 +125,16 @@ export default class ol_legend_Legend {
    * @return {CanvasElement}
    */
   getLegendImage(item: olLegendItemOptions, canvas?: HTMLCanvasElement, offsetY?: number): HTMLCanvasElement;
+
+  // The following function is already declared in ol/Object.d.ts
+  // but we still have to redeclare it here, otherwise it's being hidden
+  // by set(size: Size), which is declared above.
+  /**
+   * Sets a value.
+   * @param {string} key Key name.
+   * @param {*} value Value.
+   * @param {boolean} [opt_silent] Update without triggering an event.
+   * @api
+   */
+  set(key: string, value: any, opt_silent?: boolean | undefined): void;
 }

--- a/@types/ol-ext/legend/Legend.d.ts
+++ b/@types/ol-ext/legend/Legend.d.ts
@@ -66,7 +66,7 @@ export default class ol_legend_Legend {
   /** Set legend size
    * @param {ol.size} size
    */
-  set(key: any, value: any, opt_silent: any): void;
+  set(size: Size): void;
 
   /** Get legend list element
    * @returns {Element}


### PR DESCRIPTION
Based on [ol-ext official examples](https://viglino.github.io/ol-ext/examples/legend/map.control.legend.html), on its [documentation](https://viglino.github.io/ol-ext/doc/doc-pages/global.html#olLegendItemOptions__anchor), and also on my personal experience of a project using ol-ext under Angular which is running in production now since several months, I had to make the following fixes to your source code for it to work with my already running in production codebase :
- the `extent` option of LayerSwitcher constructor is of type `boolean`, and not of type `Extent`, cf. [official doc of LayerSwitcher](https://viglino.github.io/ol-ext/doc/doc-pages/ol.control.LayerSwitcher.html)
- the Legend's function `set(size)` only takes on parameter, cf. [doc of Legend](https://viglino.github.io/ol-ext/doc/doc-pages/ol.legend.Legend.html)
- the LegendItem constructor options `className`, `style`, `textStyle`, and `size` are all optional, cf. [official example not using those options](https://viglino.github.io/ol-ext/examples/legend/map.control.legend.html)
- the LegendItem constructor options `width` and `height` were missing, cf. [official doc](https://viglino.github.io/ol-ext/doc/doc-pages/global.html#olLegendItemOptions)
- I also had to add `extends BaseObject` to the declaration of classes `LegendItem` and `ol_legend_Legend` (because they really do derive from `BaseObject`) in order to get the right to call some functions inherited from `BaseObject` (for adding custom properties with `setProperties()` / `getProperties()` family of functions)
