### PR TITLE
options.offset type is incomplete in both style/FillPattern and style/StrokePattern

### DIFF
--- a/@types/ol-ext/control/LayerSwitcher.d.ts
+++ b/@types/ol-ext/control/LayerSwitcher.d.ts
@@ -39,7 +39,7 @@ export interface Options extends ControlOptions {
   reordering?: boolean;
   trash?: boolean;
   oninfo?: (l: Layer) => void;
-  extent?: Extent;
+  extent?: boolean;
   onExtent?: (l: Layer) => void;
   drawDelay?: number;
   collapsed?: boolean;

--- a/@types/ol-ext/legend/Item.d.ts
+++ b/@types/ol-ext/legend/Item.d.ts
@@ -1,3 +1,4 @@
+import type BaseObject from 'ol/Object';
 import type Feature from 'ol/Feature'
 import type { StyleLike } from 'ol/style/Style'
 import type { Size } from 'ol/size'
@@ -62,7 +63,7 @@ export type olLegendItemOptions = {
  * @constructor
  * @fires select
  */
-export default class LegendItem {
+export default class LegendItem extends BaseObject {
   /**
    * @param {olLegendItemOptions} options
    */

--- a/@types/ol-ext/legend/Item.d.ts
+++ b/@types/ol-ext/legend/Item.d.ts
@@ -11,7 +11,7 @@ export type olLegendItemOptions = {
    * row title
    */
   title: string;
-  className: string;
+  className?: string;
   /**
    * a feature to draw on the legend
    */
@@ -25,10 +25,21 @@ export type olLegendItemOptions = {
    */
   properties?: any;
   /**
-   * a style or a style function to use to draw the legend
+   * a style or a style function to use to draw the legend symbol
    */
-  style: StyleLike;
-  textStyle: Text
+  style?: StyleLike;
+  /**
+   * a text style to draw the item title in the legend
+   */
+  textStyle?: Text;
+  /**
+   * the symbol width, default use the default width
+   */
+  width?: number;
+  /**
+   * the symbol height, default use the default height
+   */
+  height?: number;
   size?: Size
   margin?: number
 };
@@ -41,6 +52,8 @@ export type olLegendItemOptions = {
  *  @property {Object} properties a set of properties to use with a style function
  *  @property {StyleLike} style a style or a style function to use to draw the legend symbol
  *  @property {Text} textStyle a text style to draw the item title in the legend
+ *  @property {number|undefined} width the symbol width, default use the default width
+ *  @property {number|undefined} height the symbol height, default use the default height
  *  @property {Size|undefined} size
  *  @property {number|undefined} margin
  */

--- a/@types/ol-ext/legend/Legend.d.ts
+++ b/@types/ol-ext/legend/Legend.d.ts
@@ -5,6 +5,7 @@ import type { Size } from 'ol/size'
 import type Layer from 'ol/layer/Layer'
 import type ol_legend_Item from './Item'
 import type { olLegendItemOptions } from './Item'
+import type BaseObject from 'ol/Object';
 
 export interface Options {
   title?: string;
@@ -22,7 +23,7 @@ export interface Options {
  * @fires select
  * @fires refresh
  */
-export default class ol_legend_Legend {
+export default class ol_legend_Legend extends BaseObject {
   /** Get a symbol image for a given legend item
    * @param {olLegendItemOptions} item
    * @param {Canvas|undefined} canvas a canvas to draw in, if none creat one
@@ -124,4 +125,16 @@ export default class ol_legend_Legend {
    * @return {CanvasElement}
    */
   getLegendImage(item: olLegendItemOptions, canvas?: HTMLCanvasElement, offsetY?: number): HTMLCanvasElement;
+
+  // The following function is already declared in ol/Object.d.ts
+  // but we still have to redeclare it here, otherwise it's being hidden
+  // by set(size: Size), which is declared above.
+  /**
+   * Sets a value.
+   * @param {string} key Key name.
+   * @param {*} value Value.
+   * @param {boolean} [opt_silent] Update without triggering an event.
+   * @api
+   */
+  set(key: string, value: any, opt_silent?: boolean | undefined): void;
 }

--- a/@types/ol-ext/legend/Legend.d.ts
+++ b/@types/ol-ext/legend/Legend.d.ts
@@ -66,7 +66,7 @@ export default class ol_legend_Legend {
   /** Set legend size
    * @param {ol.size} size
    */
-  set(key: any, value: any, opt_silent: any): void;
+  set(size: Size): void;
 
   /** Get legend list element
    * @returns {Element}

--- a/@types/ol-ext/style/FillPattern.d.ts
+++ b/@types/ol-ext/style/FillPattern.d.ts
@@ -24,7 +24,7 @@ export interface Options {
   opacity?: number;
   color?: Color | ColorLike;
   fill?: Fill;
-  offset?: number;
+  offset?: number | [number, number];
   size?: number;
   spacing?: number;
   angle?: number | boolean;
@@ -48,7 +48,7 @@ export default class FillPattern extends Fill {
    *  @param {string} options.pattern pattern name (override by image option)
    *  @param {Color|ColorLike} options.color pattern color
    *  @param {Fill} options.fill fill color (background)
-   *  @param {number} options.offset pattern offset for hash/dot/circle/cross pattern
+   *  @param {number|Array<number>} options.offset pattern offset for hash/dot/circle/cross pattern
    *  @param {number} options.size line size for hash/dot/circle/cross pattern
    *  @param {number} options.spacing spacing for hash/dot/circle/cross pattern
    *  @param {number|boolean} options.angle angle for hash pattern / true for 45deg dot/circle/cross

--- a/@types/ol-ext/style/StrokePattern.d.ts
+++ b/@types/ol-ext/style/StrokePattern.d.ts
@@ -9,7 +9,7 @@ export interface Options {
   color?: ColorLike;
   fill?: Fill;
   offset?: number;
-  Size?: number;
+  size?: number;
   spacing?: number;
   angle?: number | boolean;
   scale?: number;

--- a/@types/ol-ext/style/StrokePattern.d.ts
+++ b/@types/ol-ext/style/StrokePattern.d.ts
@@ -8,7 +8,7 @@ export interface Options {
   pattern?: string;
   color?: ColorLike;
   fill?: Fill;
-  offset?: number;
+  offset?: number | [number, number];
   size?: number;
   spacing?: number;
   angle?: number | boolean;
@@ -32,7 +32,7 @@ export default class StrokePattern extends Stroke {
    *  @param {string} options.pattern pattern name (override by image option)
    *  @param {ColorLike} options.color pattern color
    *  @param {Fill} options.fill fill color (background)
-   *  @param {number} options.offset pattern offset for hash/dot/circle/cross pattern
+   *  @param {number|Array<number>} options.offset pattern offset for hash/dot/circle/cross pattern
    *  @param {number} options.size line size for hash/dot/circle/cross pattern
    *  @param {number} options.spacing spacing for hash/dot/circle/cross pattern
    *  @param {number|boolean} options.angle angle for hash pattern / true for 45deg dot/circle/cross


### PR DESCRIPTION
See [ol-ext PR #955](https://github.com/Viglino/ol-ext/pull/955)

This PR also fixes a typo on option 'size' (not 'Size'!) in constructor of StrokePattern 