### PR TITLE
Replace 'npx gulp serve' to 'yarn start' in 'examples/README.md' latter part

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -55,7 +55,7 @@
    ```bash
    cd /path/to/types-ol-ext
    cd ol-ext
-   npx gulp serve
+   yarn start
    ```
 
     - Currently, TypeScript ol-ext examples are a quite few.


### PR DESCRIPTION
@Siedlerchr Thanks for updating examples!

I just realized that ol-ext `npx gulp serve` needs another option and found your update in #137. 🙇
Then, I found `examples/README.md` latter part has not been replaced, so I create this PR.