### PR TITLE
Return index.d.ts to @types/ol-ext dir

### DIFF
--- a/@types/ol-ext/index.d.ts
+++ b/@types/ol-ext/index.d.ts
@@ -1,0 +1,1 @@
+// index.d.ts


### PR DESCRIPTION
Added `index.d.ts` into `@types/ol-ext/` directory to avoid TypeScript compiler error when using the package through `npm`.

As mentioned in #133 