### PR TITLE
Add `layers` to `Options` interface

### DIFF
--- a/@types/ol-ext/interaction/Hover.d.ts
+++ b/@types/ol-ext/interaction/Hover.d.ts
@@ -27,6 +27,7 @@ export interface Options {
   cursor?: string;
   featureFilter?: (feature: Feature, layer: Layer) => boolean;
   layerFilter?: (feature: Feature) => boolean;
+  layers?: Array<Layer>;
   hitTolerance?: number;
   handleEvent: (p0: MapBrowserEvent<UIEvent>) => boolean;
 }


### PR DESCRIPTION
This adds the missing `layers` property to the `Options` interface for the Hover interaction.
It is currently only [listed under the params](https://github.com/Siedlerchr/types-ol-ext/blob/8fecee906339803abc98596bf27c62ff76726d23/%40types/ol-ext/interaction/Hover.d.ts#L46) but not present in the interface.