### PR TITLE
fix current map type

### DIFF
--- a/@types/ol-ext/interaction/CopyPaste.d.ts
+++ b/@types/ol-ext/interaction/CopyPaste.d.ts
@@ -3,7 +3,7 @@ import type Feature from 'ol/Feature'
 import type { Vector as VectorSource } from 'ol/source'
 import type MapBrowserEvent from 'ol/MapBrowserEvent'
 import BaseEvent from 'ol/events/Event'
-import { CurrentMap } from './CurrentMap'
+import CurrentMap from './CurrentMap'
 
 export enum CopyPasteEventType {
   DELETESTART = 'deletestart',

--- a/@types/ol-ext/interaction/CurrentMap.d.ts
+++ b/@types/ol-ext/interaction/CurrentMap.d.ts
@@ -32,7 +32,7 @@ export interface Options {
 
  * @extends {ol_interaction_Interaction}
  */
-declare class CurrentMap extends Interaction {
+export default class CurrentMap extends Interaction {
   /**
    * @param {*} options
    *  @param {function} condition a function that takes a mapBrowserEvent and returns true if the map must be activated, default always true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siedlerchr/types-ol-ext",
-  "version": "3.4.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siedlerchr/types-ol-ext",
-      "version": "3.4.0",
+      "version": "3.5.1",
       "license": "MIT",
       "devDependencies": {
         "@definitelytyped/dtslint": "^0.2.22",


### PR DESCRIPTION

# Changes

- update package-lock.json version 
  - 3.4.0 -> 3.5.1
  - this commit makes package-lock.json to have same version with package.json

- fix CurrentMap Type to be exported default
  - name export -> default export
  - https://github.com/Viglino/ol-ext/blob/master/src/interaction/CurrentMap.js
    - CurrentMap is exported default in ol-ext source code
