### PR TITLE
fix(typing): correct zoomOnSelect search control type

### DIFF
--- a/@types/ol-ext/control/Search.d.ts
+++ b/@types/ol-ext/control/Search.d.ts
@@ -35,8 +35,7 @@ export interface Options extends ControlOptions {
   autocomplete?: (s: string, cback: ([])) => [] | false;
   onselect?: (...params: any[]) => any;
   centerOnSelect?: boolean;
-  zoomOnSelect?: (...params: any[]) => any;
-}
+  zoomOnSelect?: number | boolean;
 
 /**
  * Search Control.


### PR DESCRIPTION
Contains the fix regarding [this issue](https://github.com/Siedlerchr/types-ol-ext/issues/174)