### PR TITLE
fix: Size -> size typo

### DIFF
--- a/@types/ol-ext/render/HexGrid.d.ts
+++ b/@types/ol-ext/render/HexGrid.d.ts
@@ -1,7 +1,7 @@
 import type { Coordinate } from 'ol/coordinate'
 
 export interface Options {
-  Size?: number;
+  size?: number;
   origin?: Coordinate;
   layout?: HexagonLayout;
 }
@@ -22,7 +22,7 @@ export declare type HexagonLayout = 'pointy' | 'flat';
 export default class HexGrid extends Object {
   /**
    * @param {Object} [options]
-   *  @param {number} [options.Size] Size of the exagon in map units, default 80000
+   *  @param {number} [options.size] size of the hexagon in map units, default 80000
    *  @param {Coordinate} [options.origin] orgin of the grid, default [0,0]
    *  @param {HexagonLayout} [options.layout] grid layout, default pointy
    */
@@ -52,13 +52,13 @@ export default class HexGrid extends Object {
    */
   getOrigin(): Coordinate;
 
-  /** Set hexagon Size
-   * @param {number} hexagon Size
+  /** Set hexagon size
+   * @param {number} hexagon size
    */
   setSize(hexagon: number): void;
 
-  /** Get hexagon Size
-   * @return {number} hexagon Size
+  /** Get hexagon size
+   * @return {number} hexagon size
    */
   getSize(): number;
 

--- a/@types/ol-ext/source/HexBin.d.ts
+++ b/@types/ol-ext/source/HexBin.d.ts
@@ -39,13 +39,13 @@ export default class HexBin extends BinBase {
    */
   getGridGeomAt(coord: Coordinate): Polygon;
 
-  /**  Set the inner HexGrid Size.
+  /**  Set the inner HexGrid size.
    *  @param {number} newSize
    *  @param {boolean} noreset If true, reset will not be called (It need to be called through)
    */
   setSize(newSize: number, noreset: boolean): void;
 
-  /**  Get the inner HexGrid Size.
+  /**  Get the inner HexGrid size.
    *  @return {number}
    */
   getSize(): number;

--- a/@types/ol-ext/source/InseeBin.d.ts
+++ b/@types/ol-ext/source/InseeBin.d.ts
@@ -9,7 +9,7 @@ import { BinBase } from './BinBase'
 
 export interface Options {
   source: VectorSource;
-  Size?: number;
+  size?: number;
   geometryFunction?: (f: Feature) => Point;
   flatAttributes?: (bin: Feature, features: Feature[]) => void;
 }
@@ -23,19 +23,19 @@ export default class InseeBin extends BinBase {
   /**
    * @param {Object} options VectorSourceOptions + grid option
    *  @param {VectorSource} options.source Source
-   *  @param {number} [options.Size] Size of the grid in meter, default 200m
+   *  @param {number} [options.size] size of the grid in meter, default 200m
    *  @param {(f: Feature) => Point} [options.geometryFunction] Function that takes an Feature as argument and returns an Point as feature's center.
    *  @param {(bin: Feature, features: Array<Feature>)} [options.flatAttributes] Function takes a bin and the features it contains and aggragate the features in the bin attributes when saving
    */
   constructor(options?: Options);
 
-  /** Set grid Size
+  /** Set grid size
    * @param {number} size
    */
   setSize(size: number): void;
 
-  /** Get grid Size
-   * @return {number} Size
+  /** Get grid size
+   * @return {number} size
    */
   getSize(): number;
 


### PR DESCRIPTION
On several places, `Size` parameter was incorrectly capitalized - see [source ol-ext lib](https://github.com/Viglino/ol-ext/blob/4f16b04858f717bd7c3baf7f9e142209ef0f4c0c/src/render/HexGrid.js#L31)