### PR TITLE
Add optional property 'crossOrigin' to the constructor of GeoImage

### DIFF
--- a/@types/ol-ext/source/GeoImage.d.ts
+++ b/@types/ol-ext/source/GeoImage.d.ts
@@ -12,6 +12,7 @@ export interface Options {
   imageRotate?: number;
   imageCrop?: Extent;
   imageMask?: Coordinate[];
+  crossOrigin?: string;
 }
 
 /** Layer source with georeferencement to place it on a map


### PR DESCRIPTION
Fixes #188