### PR TITLE
Fix Legend to support nested ol_legend_Legend

### DIFF
--- a/@types/ol-ext/legend/Legend.d.ts
+++ b/@types/ol-ext/legend/Legend.d.ts
@@ -3,6 +3,7 @@ import type { Style, Text } from 'ol/style'
 import type { StyleFunction, StyleLike } from 'ol/style/Style'
 import type { Size } from 'ol/size'
 import type Layer from 'ol/layer/Layer'
+import type ol_legend_Image from './Image'
 import type ol_legend_Item from './Item'
 import type { olLegendItemOptions } from './Item'
 import BaseObject from 'ol/Object';
@@ -85,9 +86,9 @@ export default class ol_legend_Legend extends BaseObject {
   setStyle(style: Style | Array<Style> | StyleFunction | undefined): void;
 
   /** Add a new item to the legend
-   * @param {olLegendItemOptions|ol_legend_Item} item
+   * @param {olLegendItemOptions|ol_legend_Item|ol_legend_Image|ol_legend_Legend} item
    */
-  addItem(item: olLegendItemOptions | ol_legend_Item): void;
+  addItem(item: olLegendItemOptions | ol_legend_Item | ol_legend_Image | ol_legend_Legend): void;
 
   /** Get item collection
    * @param {ol_Collection}


### PR DESCRIPTION
Hey,

`ol_legend_Legend`.`addItem` is missing the supported type `ol_legend_Legend` that allows to create nested legends as shown in ol-ext source code and examples.

https://github.com/Viglino/ol-ext/blob/master/src/legend/Legend.js#L326
```
  /** Add a new item to the legend
   * @param {olLegendItemOptions|ol_legend_Item} item
   */
  addItem(item) {
    if (item instanceof ol_legend_Legend) {
      this._items.push(item)
      item.on('refresh', function() { this.refresh(true) }.bind(this))
    } else if (item instanceof ol_legend_Item || item instanceof ol_legend_Image) {
      this._items.push(item)
    } else {
      this._items.push(new ol_legend_Item(item))
    }
  }
```
_(As seen, the code documentation is not up to date though; also https://viglino.github.io/ol-ext/doc/doc-pages/ol.legend.Legend.html#addItem__anchor)_

https://github.com/Viglino/ol-ext/blob/master/examples/legend/map.control.legend.layer.html
```
  // New legend associated with a layer
  var layerLegend = new ol.legend.Legend({ layer: geology })

  layerLegend.addItem(new ol.legend.Image({
    title: 'Geology',
    src: 'http://geoservices.brgm.fr/geologie?language=fre&version=1.3.0&service=WMS&request=GetLegendGraphic&sld_version=1.1.0&layer=GEOSERVICES_GEOLOGIE&format=image/png&STYLE=default'
  }))

...

  legend.addItem(layerLegend)
```

Also: https://github.com/Viglino/ol-ext/blob/master/examples/legend/map.control.legends.html

This fixes TypeScript error which tries to infer the `ol_legend_Legend` to a` LegendItem` :
> Argument of type 'ol_legend_Legend' is not assignable to parameter of type 'LegendItem | olLegendItemOptions'.
>   Property 'getElement' is missing in type 'ol_legend_Legend' but required in type 'LegendItem'.ts(2345)

I also added the missing `ol_legend_Image` type which does not cause any issues right now but could break in the future if signatures change.